### PR TITLE
운동 경기 모집 게시판 2차 프론트엔드 프로세스 구조 구현

### DIFF
--- a/src/components/PostsList.jsx
+++ b/src/components/PostsList.jsx
@@ -4,14 +4,27 @@ export default function PostsList({ posts }) {
       {posts.map((post) => (
         <li key={post.id}>
           <p>
+            {post.author}
+          </p>
+          <p>
             {post.detail}
           </p>
           <p>
-            참가인원:
-            {' '}
-            {post.participants.length}
+            {post.membersCount}
+            명/
+            {post.targetMembersCount}
             명
           </p>
+          {post.positions.map((position) => (
+            <p key={position.id}>
+              {position.name}
+              (
+              {position.currentParticipants}
+              /
+              {position.targetParticipantsCount}
+              )
+            </p>
+          ))}
         </li>
       ))}
     </ul>

--- a/src/components/PostsList.test.jsx
+++ b/src/components/PostsList.test.jsx
@@ -7,37 +7,64 @@ describe('PostsList', () => {
     const posts = [
       {
         id: 1,
-        detail: '한화 상대로 함께 경기 뛸 인원 모집합니다.',
-        participants: [
-          { id: 1, name: '참가자 1' },
-          { id: 2, name: '참가자 2' },
+        author: '작성자 1',
+        detail: '동네 야구대회 나가실 분 모집합니다',
+        membersCount: 4,
+        targetMembersCount: 12,
+        positions: [
+          {
+            id: 1,
+            name: '투수',
+            currentParticipants: 0,
+            targetParticipantsCount: 3,
+          },
+          {
+            id: 2,
+            name: '내야수',
+            currentParticipants: 2,
+            targetParticipantsCount: 5,
+          },
+          {
+            id: 3,
+            name: '외야수',
+            currentParticipants: 2,
+            targetParticipantsCount: 4,
+          },
         ],
       },
       {
-        id: 2,
-        detail: '모집한다고',
-        participants: [
-          { id: 1, name: '참가자 1' },
-          { id: 2, name: '참가자 2' },
-          { id: 3, name: '참가자 3' },
-          { id: 4, name: '참가자 4' },
-          { id: 5, name: '참가자 5' },
+        id: 3,
+        author: '작성자 2',
+        detail: '풋살마렵네 재야의 고수들 모여라',
+        membersCount: 5,
+        targetMembersCount: 6,
+        positions: [
+          {
+            id: 4,
+            name: '자유포지션',
+            currentParticipants: 5,
+            targetParticipantsCount: 6,
+          },
         ],
       },
     ];
 
-    it('애플리케이션 이름, 운동 선택하기, 사이드바 메뉴 펼치기 버튼 존재', () => {
+    it('썸네일 출력', () => {
       render((
         <PostsList
           posts={posts}
         />
       ));
 
-      screen.getByText(/한화 상대로 함께 경기 뛸 인원 모집합니다/);
-      screen.getByText(/참가인원: 2명/);
+      screen.getByText(/작성자 1/);
+      screen.getByText(/4명\/12명/);
+      screen.getByText(/투수/);
+      screen.getByText(/내야수/);
+      screen.getByText(/외야수/);
 
-      screen.getByText(/모집한다고/);
-      screen.getByText(/참가인원: 5명/);
+      screen.getByText(/작성자 2/);
+      screen.getByText(/5명\/6명/);
+      screen.getByText(/자유포지션/);
     });
   });
 });

--- a/src/pages/PostsListPage.jsx
+++ b/src/pages/PostsListPage.jsx
@@ -11,6 +11,8 @@ export default function PostsListPage() {
 
   const { posts } = postStore;
 
+  // TODO: 게시글 클릭 시 게시글 상세 페이지로 링크 연결
+
   return (
     <PostsList
       posts={posts}

--- a/src/pages/PostsListPage.test.jsx
+++ b/src/pages/PostsListPage.test.jsx
@@ -17,30 +17,10 @@ describe('PostsListPage', () => {
     ));
   }
 
-  context('운동 모집 게시글이 존재하는 경우', () => {
-    posts = [
-      {
-        id: 3,
-        detail: '자전거 남산 업힐 5분 주파 팀원 모집합니다',
-        participants: [
-          { id: 1, name: '참가자 1' },
-          { id: 2, name: '참가자 2' },
-          { id: 3, name: '참가자 3' },
-        ],
-      },
-      {
-        id: 6,
-        detail: '배드민턴 고?',
-        participants: [
-          { id: 1, name: '참가자 1' },
-          { id: 2, name: '참가자 2' },
-          { id: 3, name: '참가자 3' },
-          { id: 4, name: '참가자 4' },
-        ],
-      },
-    ];
+  context('운동 모집 게시글 조회 페이지가 호출되면', () => {
+    posts = [];
 
-    it('운동 모집 게시글 출력', () => {
+    it('운동 모집 게시글 출력을 위한 fetchPosts 수행', () => {
       renderPostsPage();
 
       expect(fetchPosts).toBeCalled();

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -10,7 +10,8 @@ export default class PostApiService {
   async fetchPosts() {
     const url = `${apiBaseUrl}/posts/list`;
     const { data } = await axios.get(url);
-    return data.posts;
+    // console.log(data);
+    return data;
   }
 }
 

--- a/src/stores/PostStore.js
+++ b/src/stores/PostStore.js
@@ -20,8 +20,39 @@ export default class PostStore {
   }
 
   async fetchPosts() {
-    this.posts = await postApiService.fetchPosts();
+    const data = await postApiService.fetchPosts();
+    this.makePostsList(data);
     this.publish();
+  }
+
+  makePostsList(data) {
+    const fetchedPosts = data.posts;
+    const fetchedTeams = data.teams;
+    const fetchedPositions = data.positions;
+
+    this.posts = Array(fetchedPosts.length).fill({}).map((_, index) => {
+      const post = fetchedPosts[index];
+      const foundTeam = fetchedTeams.find((team) => (
+        team.postId === post.id
+      ));
+      const foundPositions = fetchedPositions.filter((position) => (
+        position.teamId === foundTeam.id
+      ));
+
+      return {
+        id: post.id,
+        author: post.author,
+        detail: post.detail,
+        membersCount: foundTeam.membersCount,
+        targetMembersCount: foundTeam.targetMembersCount,
+        positions: foundPositions.map((position) => ({
+          id: position.id,
+          name: position.name,
+          currentParticipants: position.currentParticipants,
+          targetParticipantsCount: position.targetParticipantsCount,
+        })),
+      };
+    });
   }
 }
 

--- a/src/stores/PostStore.test.js
+++ b/src/stores/PostStore.test.js
@@ -18,15 +18,19 @@ afterAll(() => {
 describe('PostStore', () => {
   const postStore = new PostStore();
 
-  context('API 서버에 게시글을 요청할 경우', () => {
-    it('게시글을 가져와 상태에 저장', async () => {
+  context('API 서버에 게시글 리스트 데이터를 요청할 경우', () => {
+    it('게시글, 팀, 포지션 정보를 조합해 게시글 리스트를 생성해 상태로 저장', async () => {
       await postStore.fetchPosts();
 
       expect(postStore.posts.length).toBe(2);
-      expect(postStore.posts[0].detail).toContain('야구한판');
-      expect(postStore.posts[0].participants[3].name).toBe('가르시아');
-      expect(postStore.posts[1].detail).toContain('볼링 한겜 고고씽');
-      expect(postStore.posts[1].participants[1].name).toBe('물트리버');
+      expect(postStore.posts[0].detail).toContain('동네 야구대회');
+      expect(postStore.posts[0].membersCount).toBe(4);
+      expect(postStore.posts[0].targetMembersCount).toBe(12);
+      expect(postStore.posts[0].positions.length).toBe(3);
+      expect(postStore.posts[1].detail).toContain('풋살마렵네');
+      expect(postStore.posts[1].membersCount).toBe(5);
+      expect(postStore.posts[1].targetMembersCount).toBe(6);
+      expect(postStore.posts[1].positions.length).toBe(1);
     });
   });
 });

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -13,21 +13,59 @@ const server = setupServer(
       posts: [
         {
           id: 1,
-          detail: '롯데 자이언츠 선수단과 함께하는 야구한판',
-          participants: [
-            { id: 1, name: '김주찬' },
-            { id: 2, name: '조성환' },
-            { id: 3, name: '홍성흔' },
-            { id: 4, name: '가르시아' },
-          ],
+          author: '작성자 1',
+          detail: '동네 야구대회 나가실 분 모집합니다',
         },
         {
-          id: 7,
-          detail: '볼링 한겜 고고씽',
-          participants: [
-            { id: 1, name: '리트리버' },
-            { id: 2, name: '물트리버' },
-          ],
+          id: 3,
+          author: '작성자 2',
+          detail: '풋살마렵네 재야의 고수들 모여라',
+        },
+      ],
+      teams: [
+        {
+          id: 1,
+          postId: 1,
+          name: '단일 팀',
+          membersCount: 4,
+          targetMembersCount: 12,
+        },
+        {
+          id: 2,
+          postId: 3,
+          name: '단일 팀',
+          membersCount: 5,
+          targetMembersCount: 6,
+        },
+      ],
+      positions: [
+        {
+          id: 1,
+          teamId: 1,
+          name: '투수',
+          currentParticipants: 0,
+          targetPartipantsCount: 3,
+        },
+        {
+          id: 2,
+          teamId: 1,
+          name: '내야수',
+          currentParticipants: 2,
+          targetPartipantsCount: 5,
+        },
+        {
+          id: 3,
+          teamId: 1,
+          name: '외야수',
+          currentParticipants: 2,
+          targetPartipantsCount: 4,
+        },
+        {
+          id: 4,
+          teamId: 2,
+          name: '자유포지션',
+          currentParticipants: 5,
+          targetPartipantsCount: 6,
         },
       ],
     })))),


### PR DESCRIPTION
본래 계획했었던 구조
- PostsList
  - 글 작성자 이름 표출
- PostsListPage (PostsPage에서 수정)
- PostStore
  - 가지고 있을 상태 내용
    - 게시글 리스트에 다음 내용 추가
      - 포지션 리스트
        - 참가자 리스트
- PostApiService
  - 가져오는 구조 수정

2뽀모 수행 중 중단, 2차 모델 재구성 다시 수행
재구성한 모델을 기준으로 구현 다시 수행

API에서 Dto에 id를 기준으로 내용을 리스트로 각각 담아서 주면,
Store에서는 id를 기준으로 내용을 조합해 post 썸네일을 만들어 배열로 구성
페이지에서는 Store에서 만들어놓은 배열을 가져와 컴포넌트에 전달
컴포넌트는 뿌리기만 함

예상 뽀모: 4뽀모
실제 뽀모: 4.5뽀모