### PR TITLE
화면 하단 네비게이터 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,10 +11,17 @@ import PostPage from './pages/PostPage';
 import WritePage from './pages/WritePage';
 import CreateClubPage from './pages/CreateClubPage';
 import ClubsPage from './pages/ClubsPage';
+import BottomNavigator from './components/BottomNavigator';
 
 const Container = styled.div`
   max-width: 768px;
   min-height: 1024px;
+`;
+
+const Wrapper = styled.div`
+  margin: 4em auto;
+  height: 100%;
+  width: 100%;
 `;
 
 export default function App() {
@@ -22,18 +29,21 @@ export default function App() {
     <Container>
       <Reset />
       <Header />
-      <Routes>
-        <Route path="/" element={<HomePage />} />
+      <BottomNavigator />
+      <Wrapper>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
 
-        {/* TODO: ExerciseListPage는 파라미터의 전달이 많이 이루어져야 한다. 어떻게 구분할 것인가? */}
-        <Route path="/posts/list" element={<PostsListPage />} />
+          {/* TODO: ExerciseListPage는 파라미터의 전달이 많이 이루어져야 한다. 어떻게 구분할 것인가? */}
+          <Route path="/posts/list" element={<PostsListPage />} />
 
-        <Route path="/posts/map" element={<PostsMapPage />} />
-        <Route path="/posts/:postId" element={<PostPage />} />
-        <Route path="/write" element={<WritePage />} />
-        <Route path="/clubs" element={<ClubsPage />} />
-        <Route path="/clubs/create" element={<CreateClubPage />} />
-      </Routes>
+          <Route path="/posts/map" element={<PostsMapPage />} />
+          <Route path="/posts/:postId" element={<PostPage />} />
+          <Route path="/write" element={<WritePage />} />
+          <Route path="/clubs" element={<ClubsPage />} />
+          <Route path="/clubs/create" element={<CreateClubPage />} />
+        </Routes>
+      </Wrapper>
     </Container>
   );
 }

--- a/src/components/BottomNavigator.jsx
+++ b/src/components/BottomNavigator.jsx
@@ -1,0 +1,49 @@
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Container = styled.nav`
+  position: fixed;
+  bottom: 0;
+  height: 4em;
+  width: 100%;
+  display: grid;
+  grid-template-rows: 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+`;
+
+export default function BottomNavigator() {
+  const navigate = useNavigate();
+
+  const handleClickButton = (link) => {
+    navigate(link);
+  };
+
+  return (
+    <Container>
+      <button
+        type="button"
+        onClick={() => handleClickButton('/home')}
+      >
+        홈
+      </button>
+      <button
+        type="button"
+        onClick={() => handleClickButton('/posts')}
+      >
+        운동
+      </button>
+      <button
+        type="button"
+        onClick={() => handleClickButton('/club')}
+      >
+        클럽
+      </button>
+      <button
+        type="button"
+        onClick={() => handleClickButton('/chat')}
+      >
+        채팅
+      </button>
+    </Container>
+  );
+}

--- a/src/components/BottomNavigator.test.jsx
+++ b/src/components/BottomNavigator.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+
+import context from 'jest-plugin-context';
+import { MemoryRouter } from 'react-router-dom';
+
+import BottomNavigator from './BottomNavigator';
+
+describe('BottomNavigator', () => {
+  context('하단 네비게이터 확인 시', () => {
+    it('홈, 운동, 클럽, 채팅 버튼 출력', () => {
+      render((
+        <MemoryRouter>
+          <BottomNavigator />
+        </MemoryRouter>
+      ));
+
+      screen.getByText(/홈/);
+      screen.getByText(/운동/);
+      screen.getByText(/클럽/);
+      screen.getByText(/채팅/);
+    });
+  });
+});

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,7 +2,8 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Container = styled.header`
-  position: absolute;
+  position: fixed;
+  top: 0;
   height: 4em;
   width: 100%;
   display: grid;

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -48,7 +48,7 @@ const server = setupServer(
           exerciseGender: '남성',
           membersCount: 4,
           targetMembersCount: 12,
-          cost: 5000,
+          cost: 10000,
         },
         {
           id: 2,
@@ -134,13 +134,13 @@ const server = setupServer(
       places: [
         {
           id: 1,
+          postId: 1,
           name: '구의야구공원',
-          teamId: 1,
         },
         {
           id: 2,
+          postId: 2,
           name: '자양중학교',
-          teamId: 2,
         },
       ],
     })))),


### PR DESCRIPTION
홈, 글 보기, 내 클럽 보기, 내 채팅 보기
버튼 생성 후 링크 연결
- 홈 >> 홈
- 운동 >> 모집글 보기
- 클럽 >> 내 클럽 보기
- 채팅 >> 내 채팅 보기

헤더, 하단 네비게이터는 fixed 영역으로
화면 상, 하단의 항상 똑같은 자리를 차지하게 해야 할 것 같다.

그리고 나머지 컨테이너 화면은 헤더, 푸터만큼의 자리를 margin으로 줘서
그 영역에는 들어가지 못하게 하는 정도만 해놓으면 될듯

예상 뽀모: 1뽀모
실제 뽀모: 1뽀모

Wrapper 컴포넌트도 만들어서 다른 페이지는 Wrapper 안에서만 생성되도록 했음