### PR TITLE
게시글 상세정보 조회 시 신청 여부에 따라 신청하기/신청취소 버튼을 구분해 출력

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
                 "react-dom": "^18.2.0",
                 "react-router-dom": "^6.4.2",
                 "styled-components": "^5.3.6",
-                "styled-reset": "^4.4.2"
+                "styled-reset": "^4.4.2",
+                "usehooks-ts": "^2.9.1"
             },
             "devDependencies": {
                 "@codeceptjs/configure": "^0.10.0",
@@ -14279,6 +14280,19 @@
                 "node": ">=4"
             }
         },
+        "node_modules/usehooks-ts": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+            "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
+            "engines": {
+                "node": ">=16.15.0",
+                "npm": ">=8"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0  || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/util": {
             "version": "0.12.5",
             "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -25743,6 +25757,12 @@
             "requires": {
                 "prepend-http": "^2.0.0"
             }
+        },
+        "usehooks-ts": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+            "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
+            "requires": {}
         },
         "util": {
             "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.2",
         "styled-components": "^5.3.6",
-        "styled-reset": "^4.4.2"
+        "styled-reset": "^4.4.2",
+        "usehooks-ts": "^2.9.1"
     }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,10 @@ import { Route, Routes } from 'react-router-dom';
 import styled from 'styled-components';
 import { Reset } from 'styled-reset';
 
+import { useEffect } from 'react';
+
+import { postApiService } from './services/PostApiService';
+
 import Header from './components/Header';
 import HomePage from './pages/HomePage';
 import PostListPage from './pages/PostListPage';
@@ -25,6 +29,9 @@ const Wrapper = styled.div`
 `;
 
 export default function App() {
+  const accessToken = localStorage.getItem('accessToken');
+  postApiService.setAccessToken(accessToken);
+
   return (
     <Container>
       <Reset />

--- a/src/components/PostPositions.jsx
+++ b/src/components/PostPositions.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-nested-ternary */
+
 import styled from 'styled-components';
 
 const Container = styled.article`
@@ -21,59 +23,83 @@ export default function PostPositions({ teamsAndPositions }) {
 
   };
 
+  const handleClickCancelRegisterExercise = () => {
+
+  };
+
+  console.log(teamsAndPositions);
+
   return (
     <Container>
-      <Team>
-        {teamsAndPositions.map((team) => (
-          <li key={team.id}>
-            <p>{team.name}</p>
-            <p>
-              {team.membersCount}
-              /
-              {team.targetMembersCount}
-              명
-            </p>
-            <Position>
-              {team.roles.map((role) => (
-                <li key={role.id}>
-                  <p>{role.name}</p>
-                  <p>
-                    {role.currentParticipants}
-                    명 신청 중/
-                    {role.targetParticipantsCount}
-                    명
-                  </p>
-                  {role.currentParticipants < role.targetParticipantsCount
-                    ? (
-                      <button
-                        type="button"
-                        onClick={handleClickRegisterExercise}
-                      >
-                        신청하기
-                      </button>
-                    ) : (
-                      <p>신청마감</p>
-                    )}
-                  <Member>
-                    {role.members.map((member) => (
-                      <li key={member.id}>
-                        <p>{member.name}</p>
-                        <p>
-                          매너점수:
-                          {' '}
-                          {member.mannerScore}
-                          점
-                        </p>
-                      </li>
-                    ))}
-                  </Member>
-                </li>
-              ))}
-            </Position>
-          </li>
-        ))}
-      </Team>
-
+      {teamsAndPositions.teams ? (
+        <Team>
+          {teamsAndPositions.teams.map((team) => (
+            <li key={team.id}>
+              <p>{team.name}</p>
+              <p>
+                {team.membersCount}
+                /
+                {team.targetMembersCount}
+                명
+              </p>
+              <Position>
+                {team.roles.map((role) => (
+                  <li key={role.id}>
+                    <p>{role.name}</p>
+                    <p>
+                      {role.currentParticipants}
+                      명 신청 중/
+                      {role.targetParticipantsCount}
+                      명
+                    </p>
+                    {teamsAndPositions.userStatus === 'isRegistered'
+                      ? (
+                        teamsAndPositions.roleIdOfAccessedUser === role.id
+                          ? (
+                            <button
+                              type="button"
+                              onClick={handleClickCancelRegisterExercise}
+                            >
+                              신청취소
+                            </button>
+                          ) : (
+                            null
+                          )
+                      ) : (
+                        role.currentParticipants < role.targetParticipantsCount
+                          ? (
+                            <button
+                              type="button"
+                              onClick={handleClickRegisterExercise}
+                            >
+                              신청하기
+                            </button>
+                          ) : (
+                            <p>신청마감</p>
+                          )
+                      )}
+                    <Member>
+                      {role.members.map((member) => (
+                        <li key={member.id}>
+                          <p>{member.name}</p>
+                          <p>
+                            매너점수:
+                            {' '}
+                            {member.mannerScore}
+                            점
+                          </p>
+                        </li>
+                      ))}
+                    </Member>
+                  </li>
+                ))}
+              </Position>
+            </li>
+          ))}
+        </Team>
+      ) : (
+        <p>Now Loading...</p>
+      )}
     </Container>
   );
 }

--- a/src/components/PostPositions.test.jsx
+++ b/src/components/PostPositions.test.jsx
@@ -4,126 +4,210 @@ import PostPositions from './PostPositions';
 
 describe('게시물 정보 컴포넌트', () => {
   context('게시물 정보 컴포넌트 내용을 받아온 경우', () => {
-    const teamsAndPositions = [
-      {
-        id: 1,
-        name: '1팀',
-        membersCount: 4,
-        targetMembersCount: 12,
-        roles: [
-          {
-            id: 1,
-            teamId: 1,
-            name: '투수',
-            currentParticipants: 3,
-            targetParticipantsCount: 3,
-            members: [
-              {
-                id: 1,
-                roleId: 1,
-                name: '참가자 1',
-                mannerScore: 7.5,
-              },
-              {
-                id: 2,
-                roleId: 1,
-                name: '참가자 2',
-                mannerScore: 3.3,
-              },
-              {
-                id: 3,
-                roleId: 1,
-                name: '참가자 3',
-                mannerScore: 5,
-              },
-            ],
-          },
-          {
-            id: 2,
-            teamId: 1,
-            name: '내야수',
-            currentParticipants: 1,
-            targetParticipantsCount: 5,
-            members: [
-              {
-                id: 4,
-                roleId: 2,
-                name: '참가자 4',
-                mannerScore: 2,
-              },
-            ],
-          },
-          {
-            id: 3,
-            teamId: 1,
-            name: '외야수',
-            currentParticipants: 0,
-            targetParticipantsCount: 4,
-            members: [],
-          },
-        ],
-      },
-      {
-        id: 2,
-        name: '2팀',
-        membersCount: 2,
-        targetMembersCount: 12,
-        roles: [
-          {
-            id: 4,
-            teamId: 2,
-            name: '자유포지션',
-            currentParticipants: 2,
-            targetParticipantsCount: 12,
-            members: [
-              {
-                id: 11,
-                roleId: 2,
-                name: '참가자 11',
-                mannerScore: 6.9,
-              },
-              {
-                id: 12,
-                roleId: 2,
-                name: '참가자 12',
-                mannerScore: 8.8,
-              },
-            ],
-          },
-        ],
-      },
-    ];
+    context('현재 접속자가 게시글에 신청하지 않은 사용자인 경우', () => {
+      const teamsAndPositions = {
+        userStatus: 'isNotRegistered',
+        roleIdOfAccessedUser: 0,
+        teams: [{
+          id: 1,
+          name: '1팀',
+          membersCount: 4,
+          targetMembersCount: 12,
+          roles: [
+            {
+              id: 1,
+              teamId: 1,
+              name: '투수',
+              currentParticipants: 3,
+              targetParticipantsCount: 3,
+              members: [
+                {
+                  id: 1,
+                  roleId: 1,
+                  name: '참가자 1',
+                  mannerScore: 7.5,
+                },
+                {
+                  id: 2,
+                  roleId: 1,
+                  name: '참가자 2',
+                  mannerScore: 3.3,
+                },
+                {
+                  id: 3,
+                  roleId: 1,
+                  name: '참가자 3',
+                  mannerScore: 5,
+                },
+              ],
+            },
+            {
+              id: 2,
+              teamId: 1,
+              name: '내야수',
+              currentParticipants: 1,
+              targetParticipantsCount: 5,
+              members: [
+                {
+                  id: 4,
+                  roleId: 2,
+                  name: '참가자 4',
+                  mannerScore: 2,
+                },
+              ],
+            },
+            {
+              id: 3,
+              teamId: 1,
+              name: '외야수',
+              currentParticipants: 0,
+              targetParticipantsCount: 4,
+              members: [],
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: '2팀',
+          membersCount: 2,
+          targetMembersCount: 12,
+          roles: [
+            {
+              id: 4,
+              teamId: 2,
+              name: '자유포지션',
+              currentParticipants: 2,
+              targetParticipantsCount: 12,
+              members: [
+                {
+                  id: 11,
+                  roleId: 2,
+                  name: '참가자 11',
+                  mannerScore: 6.9,
+                },
+                {
+                  id: 12,
+                  roleId: 2,
+                  name: '참가자 12',
+                  mannerScore: 8.8,
+                },
+              ],
+            },
+          ],
+        }],
+      };
 
-    it('화면에 게시글의 모든 내용을 출력', () => {
-      render((
-        <PostPositions
-          teamsAndPositions={teamsAndPositions}
-        />
-      ));
+      it('화면에 게시글의 내용을 출력하고 모든 포지션에 신청하기 버튼을 출력', () => {
+        render((
+          <PostPositions
+            teamsAndPositions={teamsAndPositions}
+          />
+        ));
 
-      screen.getByText(/1팀/);
-      screen.getByText(/4\/12명/);
+        screen.getByText(/1팀/);
+        screen.getByText(/4\/12명/);
 
-      screen.getByText(/투수/);
-      screen.getByText('참가자 1');
-      screen.getByText(/참가자 2/);
-      screen.getByText(/참가자 3/);
+        screen.getByText(/투수/);
+        screen.getByText('참가자 1');
+        screen.getByText(/참가자 2/);
+        screen.getByText(/참가자 3/);
 
-      screen.getByText(/내야수/);
-      screen.getByText(/참가자 4/);
+        screen.getByText(/내야수/);
+        screen.getByText(/참가자 4/);
 
-      screen.getByText(/외야수/);
+        screen.getByText(/외야수/);
 
-      screen.getByText(/2팀/);
-      screen.getByText(/2\/12명/);
+        screen.getByText(/2팀/);
+        screen.getByText(/2\/12명/);
 
-      screen.getByText(/자유포지션/);
-      screen.getByText(/참가자 11/);
-      screen.getByText(/참가자 12/);
+        screen.getByText(/자유포지션/);
+        screen.getByText(/참가자 11/);
+        screen.getByText(/참가자 12/);
 
-      expect(screen.getAllByText(/명 신청 중/).length).toBe(4);
-      expect(screen.getAllByText(/매너점수:/).length).toBe(6);
-      expect(screen.getAllByText(/신청하기/).length).toBe(3);
+        expect(screen.getAllByText(/명 신청 중/).length).toBe(4);
+        expect(screen.getAllByText(/매너점수:/).length).toBe(6);
+        expect(screen.getAllByText(/신청하기/).length).toBe(3);
+      });
+    });
+
+    context('현재 접속자가 게시글에 신청한 사용자인 경우', () => {
+      const teamsAndPositions = {
+        userStatus: 'isRegistered',
+        roleIdOfAccessedUser: 2,
+        teams: [{
+          id: 1,
+          name: '1팀',
+          membersCount: 1,
+          targetMembersCount: 5,
+          roles: [
+            {
+              id: 1,
+              teamId: 1,
+              name: '세터',
+              currentParticipants: 0,
+              targetParticipantsCount: 2,
+              members: [],
+            },
+            {
+              id: 2,
+              teamId: 1,
+              name: '리시버',
+              currentParticipants: 1,
+              targetParticipantsCount: 2,
+              members: [
+                {
+                  id: 1,
+                  roleId: 2,
+                  name: '배구참가자',
+                  mannerScore: 10,
+                },
+              ],
+            },
+            {
+              id: 3,
+              teamId: 1,
+              name: '리베로',
+              currentParticipants: 0,
+              targetParticipantsCount: 1,
+              members: [],
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: '2팀',
+          membersCount: 1,
+          targetMembersCount: 5,
+          roles: [
+            {
+              id: 4,
+              teamId: 2,
+              name: '자유포지션',
+              currentParticipants: 1,
+              targetParticipantsCount: 5,
+              members: [
+                {
+                  id: 11,
+                  roleId: 2,
+                  name: '참가자 11',
+                  mannerScore: 6.9,
+                },
+              ],
+            },
+          ],
+        }],
+      };
+
+      it('자신이 신청한 포지션에는 신청취소 버튼이 출력되고 다른 포지션에는 버튼이 출력되지 않음', () => {
+        render((
+          <PostPositions
+            teamsAndPositions={teamsAndPositions}
+          />
+        ));
+
+        expect(screen.queryAllByText(/신청하기/).length).toBe(0);
+        screen.getByText(/신청취소/);
+      });
     });
   });
 });

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { useEffect } from 'react';
+
 import usePostStore from '../hooks/usePostStore';
 
 import PostInformation from '../components/PostInformation';

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -7,6 +7,14 @@ import config from '../config';
 const { apiBaseUrl } = config;
 
 export default class PostApiService {
+  constructor() {
+    this.accessToken = '';
+  }
+
+  setAccessToken(accessToken) {
+    this.accessToken = accessToken;
+  }
+
   async fetchPosts() {
     const url = `${apiBaseUrl}/posts/list`;
     const { data } = await axios.get(url);
@@ -15,7 +23,12 @@ export default class PostApiService {
 
   async fetchPost(postId) {
     const url = `${apiBaseUrl}/posts/${postId}`;
-    const { data } = await axios.get(url);
+    const { data } = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
+    console.log(data);
     return data;
   }
 }

--- a/src/stores/PostStore.js
+++ b/src/stores/PostStore.js
@@ -9,7 +9,7 @@ export default class PostStore {
 
     // Post
     this.postInformation = {};
-    this.postPositions = [];
+    this.postPositions = {};
 
     this.listeners = new Set();
   }
@@ -61,27 +61,31 @@ export default class PostStore {
       cost: game.cost,
     };
 
-    this.postPositions = game.teams.map((team) => ({
-      id: team.id,
-      name: team.name,
-      membersCount: team.membersCount,
-      targetMembersCount: team.targetMembersCount,
-      roles: team.roles.filter((role) => role.teamId === team.id)
-        .map((foundRole) => ({
-          id: foundRole.id,
-          teamId: foundRole.teamId,
-          name: foundRole.name,
-          currentParticipants: foundRole.currentParticipants,
-          targetParticipantsCount: foundRole.targetParticipantsCount,
-          members: foundRole.members.filter((member) => member.roleId === foundRole.id)
-            .map((foundMember) => ({
-              id: foundMember.id,
-              roleId: foundMember.roleId,
-              name: foundMember.name,
-              mannerScore: foundMember.mannerScore,
-            })),
-        })),
-    }));
+    this.postPositions = {
+      userStatus: game.userStatus,
+      roleIdOfAccessedUser: game.roleIdOfAccessedUser,
+      teams: game.teams.map((team) => ({
+        id: team.id,
+        name: team.name,
+        membersCount: team.membersCount,
+        targetMembersCount: team.targetMembersCount,
+        roles: team.roles.filter((role) => role.teamId === team.id)
+          .map((foundRole) => ({
+            id: foundRole.id,
+            teamId: foundRole.teamId,
+            name: foundRole.name,
+            currentParticipants: foundRole.currentParticipants,
+            targetParticipantsCount: foundRole.targetParticipantsCount,
+            members: foundRole.members.filter((member) => member.roleId === foundRole.id)
+              .map((foundMember) => ({
+                id: foundMember.id,
+                roleId: foundMember.roleId,
+                name: foundMember.name,
+                mannerScore: foundMember.mannerScore,
+              })),
+          })),
+      })),
+    };
   }
 
   calculateAverageMannerScore(teams) {

--- a/src/stores/PostStore.test.js
+++ b/src/stores/PostStore.test.js
@@ -2,6 +2,7 @@ import context from 'jest-plugin-context';
 import PostStore from './PostStore';
 
 import server from '../testServer';
+import { postApiService } from '../services/PostApiService';
 
 beforeAll(() => {
   server.listen();
@@ -37,6 +38,7 @@ describe('PostStore', () => {
   context('API 서버에 특정 게시글의 상세 데이터를 요청할 경우', () => {
     it('게시글, 팀, 포지션, 멤버 정보를 조합해 게시글 상세 데이터를 생성하고 상태로 저장', async () => {
       const postId = 1;
+      postApiService.setAccessToken('userId 1 is Author');
       await postStore.fetchPost(postId);
 
       const { postInformation, postPositions } = postStore;
@@ -45,9 +47,11 @@ describe('PostStore', () => {
       const positionsSize = Object.keys(postPositions).length;
 
       expect(informationSize).toBe(16);
-      expect(positionsSize).toBe(2);
-      expect(postPositions[0].roles.length).toBe(2);
-      expect(postPositions[0].roles[0].members.length).toBe(1);
+
+      expect(positionsSize).toBe(3);
+      expect(postPositions.userStatus).toBe('isAuthor');
+      expect(postPositions.teams[0].roles.length).toBe(2);
+      expect(postPositions.teams[0].roles[0].members.length).toBe(1);
     });
   });
 });

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -199,107 +199,108 @@ const server = setupServer(
 
   rest.get(`${apiBaseUrl}/posts/:postId`, async (request, response, context) => {
     const { postId } = await request.params;
+    const accessToken = await request.headers.get('Authorization');
 
-    if (postId === '1') {
+    if (postId === '1' && accessToken) {
       return response(context.json({
-        post: {
+        id: 1,
+        type: '선수 모집',
+        author: '황인우',
+        createdAt: '10/22 18:00:33',
+        hits: 15,
+        detail: '동네 야구대회 나가실 분 모집합니다',
+        images: [
+          { id: 1, url: 'Image Url 1', isThumbnailImage: false },
+          { id: 2, url: 'Image Url 2', isThumbnailImage: false },
+          { id: 3, url: 'Image Url 3', isThumbnailImage: true },
+        ],
+        game: {
           id: 1,
-          type: '선수 모집',
-          author: '야구선수 1',
-          createdAt: '10/22 18:00:33',
-          hits: 15,
-          detail: '동네 야구대회 나가실 분 모집합니다',
-          images: [
-            { id: 1, url: 'Image Url 1', isThumbnailImage: false },
-            { id: 2, url: 'Image Url 2', isThumbnailImage: false },
-            { id: 3, url: 'Image Url 3', isThumbnailImage: true },
+          postId: 1,
+          exercise: '야구',
+          exerciseDate: '10월 15일 오후 2시~5시',
+          exerciseType: '연습경기',
+          exerciseLevel: '초보',
+          exerciseGender: '남성',
+          cost: 10000,
+          place: '구의야구공원',
+          teams: [
+            {
+              id: 1,
+              gameId: 1,
+              name: '1팀',
+              membersCount: 2,
+              targetMembersCount: 12,
+              roles: [
+                {
+                  id: 1,
+                  teamId: 1,
+                  name: '투수',
+                  currentParticipants: 1,
+                  targetParticipantsCount: 3,
+                  members: [
+                    {
+                      id: 1,
+                      teamId: 1,
+                      roleId: 1,
+                      name: '황인우',
+                      mannerScore: 10.0,
+                    },
+                  ],
+                },
+                {
+                  id: 2,
+                  teamId: 1,
+                  name: '야수',
+                  currentParticipants: 1,
+                  targetParticipantsCount: 9,
+                  members: [
+                    {
+                      id: 2,
+                      teamId: 1,
+                      roleId: 2,
+                      name: '조성환',
+                      mannerScore: 7.1,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 2,
+              gameId: 1,
+              name: '2팀',
+              membersCount: 2,
+              targetMembersCount: 12,
+              roles: [
+                {
+                  id: 3,
+                  teamId: 2,
+                  name: '포지션무관',
+                  currentParticipants: 2,
+                  targetParticipantsCount: 12,
+                  members: [
+                    {
+                      id: 3,
+                      teamId: 2,
+                      roleId: 3,
+                      name: '전민지',
+                      mannerScore: 5.2,
+                    },
+                    {
+                      id: 4,
+                      teamId: 2,
+                      roleId: 3,
+                      name: '김명훈',
+                      mannerScore: 6.7,
+                    },
+                  ],
+                },
+              ],
+            },
           ],
-          game: {
-            id: 1,
-            postId: 1,
-            exercise: '야구',
-            exerciseDate: '10월 15일 오후 2시~5시',
-            exerciseType: '연습경기',
-            exerciseLevel: '초보',
-            exerciseGender: '남성',
-            cost: 10000,
-            place: '구의야구공원',
-            teams: [
-              {
-                id: 1,
-                gameId: 1,
-                name: '1팀',
-                membersCount: 2,
-                targetMembersCount: 12,
-                roles: [
-                  {
-                    id: 1,
-                    teamId: 1,
-                    name: '투수',
-                    currentParticipants: 1,
-                    targetParticipantsCount: 3,
-                    members: [
-                      {
-                        id: 1,
-                        teamId: 1,
-                        roleId: 1,
-                        name: '황인우',
-                        mannerScore: 10.0,
-                      },
-                    ],
-                  },
-                  {
-                    id: 2,
-                    teamId: 1,
-                    name: '야수',
-                    currentParticipants: 1,
-                    targetParticipantsCount: 9,
-                    members: [
-                      {
-                        id: 2,
-                        teamId: 1,
-                        roleId: 2,
-                        name: '조성환',
-                        mannerScore: 7.1,
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                id: 2,
-                gameId: 1,
-                name: '2팀',
-                membersCount: 2,
-                targetMembersCount: 12,
-                roles: [
-                  {
-                    id: 3,
-                    teamId: 2,
-                    name: '포지션무관',
-                    currentParticipants: 2,
-                    targetParticipantsCount: 12,
-                    members: [
-                      {
-                        id: 3,
-                        teamId: 2,
-                        roleId: 3,
-                        name: '전민지',
-                        mannerScore: 5.2,
-                      },
-                      {
-                        id: 4,
-                        teamId: 2,
-                        roleId: 3,
-                        name: '김명훈',
-                        mannerScore: 6.7,
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
+          userStatus: 'isAuthor',
+          roleIdOfAccessedUser: 1,
         },
       }));
     }


### PR DESCRIPTION
1. 로컬 스토리지에 사용자 Id를 JWT로 인코딩한 토큰을 저장해서 사용자를 구분
2. fetchPost(postId) 동작에는 로컬 스토리지의 토큰을 전달해서 헤더로 토큰이 전달되게 함
3. 서버로부터 받아온 데이터를 Store에서 컴포넌트에 맞게 분리시킬 때 userStatus와 roleId는 positions 쪽으로 전달한다.
4. positions 컴포넌트에서 userStatus와 roleId를 기준으로 어떤 버튼을 출력시킬지 결정한다.

예상 뽀모: 6
실제 뽀모: 13
(프론트엔드, 백엔드를 둘 다 합친 시간)

어떤 점으로 인해 오래 걸렸나?
로컬 스토리지를 저장하고 불러오는 과정을 적용하면서, testServer의 메서드와 실제 응답 데이터가 불일치해 한 쪽을 고칠 경우 다른 쪽이 오작동해 문제를 해결하면서 두 영역의 오류를 잡는 과정에서 시간이 소요되었음