### PR TITLE
운동 게시글 목록 조회 리팩터링-2: API 호출 구조 통합

### DIFF
--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -1,81 +1,51 @@
 import styled from 'styled-components';
 
-const Container = styled.ul`
+const Container = styled.article`
   margin-inline: 10em;
   display: flex;
   flex-direction: column;
   align-items: center;
 `;
 
-const Thumbnail = styled.ul`
+const Thumbnails = styled.ul`
+  
+`;
+
+const Thumbnail = styled.li`
   margin-block: 3em;
 `;
 
 // TODO: 작성자 옆에 매너 점수 필드 추가 필요
 
-export default function Posts({
-  posts, images, games, places, roles,
-}) {
+export default function Posts({ posts }) {
   if (!posts) {
     return (
-      <p>loading...</p>
+      <p>등록된 게시물이 존재하지 않습니다.</p>
     );
   }
 
   return (
     <Container>
-      {!posts ? (
-        <p>
-          등록된 게시물이 존재하지 않습니다.
-        </p>
-      ) : (
-        <ul>
-          {posts.map((post) => {
-            const foundImage = images.find((image) => image.postId === post.id);
-            const foundGame = games.find((game) => game.postId === post.id);
-            const foundPlace = places.find((place) => place.gameId === foundGame.id);
-            const foundRoles = roles.filter((role) => role.gameId === foundGame.id);
-
-            return (
-              <Thumbnail key={post.id}>
-                <div>
-                  <p>{foundGame.date}</p>
-                </div>
-                <div>
-                  <div>
-                    <img
-                      src={foundImage.url}
-                      alt={foundImage.id}
-                    />
-                  </div>
-                  <div>
-                    <p>{foundPlace.name}</p>
-                    <p>{post.author}</p>
-                    <p>
-                      총 인원:
-                      {foundGame.membersCount}
-                      /
-                      {foundGame.targetMembersCount}
-                      명
-                    </p>
-                    {foundRoles.map((role) => (
-                      <p key={role.id}>
-                        {role.name}
-                      </p>
-                    ))}
-                  </div>
-                  <div>
-                    <p>{foundGame.exercise}</p>
-                    <p>{post.hits}</p>
-                    <p>{foundGame.type}</p>
-                    <p>{foundGame.level}</p>
-                  </div>
-                </div>
-              </Thumbnail>
-            );
-          })}
-        </ul>
-      )}
+      <Thumbnails>
+        {posts.map((post) => (
+          <Thumbnail key={post.id}>
+            <p>
+              조회수:
+              {' '}
+              {post.hits}
+            </p>
+            <p>{post.game.type}</p>
+            <p>{post.game.date}</p>
+            <p>{post.game.place}</p>
+            <p>
+              {post.game.currentMemberCount}
+              /
+              {post.game.targetMemberCount}
+              명
+            </p>
+          </Thumbnail>
+        ))}
+      </Thumbnails>
     </Container>
   );
 }

--- a/src/components/Posts.test.jsx
+++ b/src/components/Posts.test.jsx
@@ -3,16 +3,10 @@ import context from 'jest-plugin-context';
 import Posts from './Posts';
 
 describe('Posts', () => {
-  const renderPosts = ({
-    posts, images, games, places, roles,
-  }) => {
+  const renderPosts = ({ posts }) => {
     render((
       <Posts
         posts={posts}
-        images={images}
-        games={games}
-        places={places}
-        roles={roles}
       />
     ));
   };
@@ -21,120 +15,48 @@ describe('Posts', () => {
     const posts = [
       {
         id: 1,
-        userId: 1,
-        author: '황인우',
-        type: '참가자 모집',
         hits: 100,
+        game: {
+          type: '야구',
+          date: '2022년 12월 19일 08:00~11:00',
+          place: '잠실야구장',
+          currentMemberCount: 4,
+          targetMemberCount: 12,
+        },
       },
       {
         id: 2,
-        userId: 2,
-        author: '전민지',
-        type: '참가자 모집',
-        hits: 10000,
-      },
-    ];
-    const images = [
-      {
-        id: 1,
-        postId: 1,
-        url: 'Image url of Post 1',
-      },
-      {
-        id: 2,
-        postId: 2,
-        url: 'Image url of Post 2',
-      },
-    ];
-    const games = [
-      {
-        id: 1,
-        postId: 1,
-        date: '2022년 11월 9일 09:00~11:00',
-        exercise: '축구',
-        type: '연습경기',
-        level: '아마추어',
-        membersCount: 13,
-        targetMembersCount: 22,
-      },
-      {
-        id: 2,
-        postId: 2,
-        date: '2022년 11월 12일 19:00~22:00',
-        exercise: '야구',
-        type: '경기',
-        level: '선출 경력 1년 이상',
-        membersCount: 8,
-        targetMembersCount: 15,
-      },
-    ];
-    const places = [
-      {
-        id: 1,
-        gameId: 1,
-        name: '상암월드컵경기장',
-      },
-      {
-        id: 2,
-        gameId: 2,
-        name: '고척스카이돔',
-      },
-    ];
-    const roles = [
-      {
-        id: 1,
-        gameId: 1,
-        name: '포지션무관',
-      },
-      {
-        id: 2,
-        gameId: 2,
-        name: '투수',
-      },
-      {
-        id: 3,
-        gameId: 2,
-        name: '야수',
-      },
-      {
-        id: 4,
-        gameId: 2,
-        name: '포수',
+        hits: 259,
+        game: {
+          type: '족구',
+          date: '2022년 12월 22일 19:00~20:00',
+          place: '세종대학교 운동장',
+          currentMemberCount: 7,
+          targetMemberCount: 8,
+        },
       },
     ];
 
     it('각 게시물의 썸네일 출력', () => {
-      renderPosts({
-        posts, images, games, places, roles,
-      });
+      renderPosts({ posts });
 
-      screen.getByText(/황인우/);
-      screen.getByAltText('1');
-      screen.getByText(/2022년 11월 9일 09:00~11:00/);
-      screen.getByText(/상암월드컵경기장/);
-      screen.getByText(/포지션무관/);
+      screen.getByText('조회수: 100');
+      screen.getByText(/2022년 12월 19일 08:00~11:00/);
+      screen.getByText(/잠실야구장/);
+      screen.getByText(/4/);
 
-      screen.getByText(/전민지/);
-      screen.getByAltText('2');
-      screen.getByText(/2022년 11월 12일 19:00~22:00/);
-      screen.getByText(/고척스카이돔/);
-      screen.getByText(/투수/);
-      screen.getByText(/야수/);
-      screen.getByText(/포수/);
+      screen.getByText('조회수: 259');
+      screen.getByText(/2022년 12월 22일 19:00~20:00/);
+      screen.getByText(/세종대학교 운동장/);
+      screen.getByText(/7/);
     });
   });
 
   context('등록된 게시글이 존재하지 않는 경우', () => {
     const posts = [];
-    const images = [];
-    const games = [];
-    const places = [];
-    const roles = [];
 
     it('게시물 미존재 안내 메세지 출력', () => {
-      renderPosts(
-        posts, images, games, places, roles,
-      );
+      renderPosts(posts);
 
       screen.getByText(/등록된 게시물이 존재하지 않습니다./);
     });

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -7,25 +7,15 @@ export default function PostsPage() {
 
   useEffect(() => {
     postStore.fetchPosts();
-    postStore.fetchImages();
-    postStore.fetchGames();
-    postStore.fetchPlaces();
-    postStore.fetchRoles();
   }, []);
 
-  const {
-    posts, images, games, places, roles,
-  } = postStore;
+  const { posts } = postStore;
 
   // TODO: 게시글 클릭 시 게시글 상세 페이지로 링크 연결
 
   return (
     <Posts
       posts={posts}
-      images={images}
-      games={games}
-      places={places}
-      roles={roles}
     />
   );
 }

--- a/src/pages/PostsPage.test.jsx
+++ b/src/pages/PostsPage.test.jsx
@@ -4,27 +4,11 @@ import { MemoryRouter } from 'react-router-dom';
 import PostsPage from './PostsPage';
 
 let posts;
-let images;
-let games;
-let places;
-let roles;
 const fetchPosts = jest.fn();
-const fetchImages = jest.fn();
-const fetchGames = jest.fn();
-const fetchPlaces = jest.fn();
-const fetchRoles = jest.fn();
 
 jest.mock('../hooks/usePostStore', () => () => ({
   posts,
-  images,
-  games,
-  places,
-  roles,
   fetchPosts,
-  fetchImages,
-  fetchGames,
-  fetchPlaces,
-  fetchRoles,
 }));
 
 describe('PostsPage', () => {
@@ -38,19 +22,10 @@ describe('PostsPage', () => {
 
   context('운동 모집 게시글 상세 조회 페이지가 호출되면', () => {
     posts = [];
-    images = [];
-    games = [];
-    places = [];
-    roles = [];
-
     it('운동 모집 게시글 상태를 가져오기 위한 fetchPost 수행', () => {
       renderPostsPage();
 
       expect(fetchPosts).toBeCalled();
-      expect(fetchImages).toBeCalled();
-      expect(fetchGames).toBeCalled();
-      expect(fetchPlaces).toBeCalled();
-      expect(fetchRoles).toBeCalled();
     });
   });
 });

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -18,31 +18,7 @@ export default class PostApiService {
   async fetchPosts() {
     const url = `${apiBaseUrl}/posts`;
     const { data } = await axios.get(url);
-    return data;
-  }
-
-  async fetchImages() {
-    const url = `${apiBaseUrl}/images/thumbnail`;
-    const { data } = await axios.get(url);
-    return data;
-  }
-
-  async fetchGames() {
-    const url = `${apiBaseUrl}/games`;
-    const { data } = await axios.get(url);
-    return data;
-  }
-
-  async fetchPlaces() {
-    const url = `${apiBaseUrl}/places`;
-    const { data } = await axios.get(url);
-    return data;
-  }
-
-  async fetchRoles() {
-    const url = `${apiBaseUrl}/roles`;
-    const { data } = await axios.get(url);
-    return data;
+    return data.posts;
   }
 
   // async fetchPost(postId) {

--- a/src/stores/PostStore.js
+++ b/src/stores/PostStore.js
@@ -5,10 +5,6 @@ import { postApiService } from '../services/PostApiService';
 export default class PostStore {
   constructor() {
     this.posts = [];
-    this.images = [];
-    this.games = [];
-    this.places = [];
-    this.roles = [];
 
     this.listeners = new Set();
   }
@@ -27,26 +23,6 @@ export default class PostStore {
 
   async fetchPosts() {
     this.posts = await postApiService.fetchPosts();
-    this.publish();
-  }
-
-  async fetchImages() {
-    this.images = await postApiService.fetchImages();
-    this.publish();
-  }
-
-  async fetchGames() {
-    this.games = await postApiService.fetchGames();
-    this.publish();
-  }
-
-  async fetchPlaces() {
-    this.places = await postApiService.fetchPlaces();
-    this.publish();
-  }
-
-  async fetchRoles() {
-    this.roles = await postApiService.fetchRoles();
     this.publish();
   }
 }

--- a/src/stores/PostStore.test.js
+++ b/src/stores/PostStore.test.js
@@ -22,28 +22,12 @@ describe('PostStore', () => {
   context('API 서버에 게시글 리스트 데이터를 요청할 경우', () => {
     it('백엔드 서버에서 응답으로 전달된 post 리스트를 상태로 저장', async () => {
       await postStore.fetchPosts();
-      await postStore.fetchImages();
-      await postStore.fetchGames();
-      await postStore.fetchPlaces();
-      await postStore.fetchRoles();
 
-      const {
-        posts, images, games, places, roles,
-      } = postStore;
+      const { posts } = postStore;
 
       expect(posts.length).toBe(2);
-      expect(posts[0].author).toBe('황인우');
-      expect(posts[1].type).toBe('참가자 모집');
-      expect(images.length).toBe(2);
-      expect(images[0].url).toBe('Image url of Post 1');
-      expect(images[1].url).toContain('2');
-      expect(games.length).toBe(2);
-      expect(games[0].exercise).toBe('축구');
-      expect(games[1].targetMembersCount).toBe(15);
-      expect(places.length).toBe(2);
-      expect(places[0].id).toBe(1);
-      expect(places[1].name).toBe('고척스카이돔');
-      expect(roles.length).toBe(4);
+      expect(posts[0].hits).toBe(334);
+      expect(posts[1].game.targetMemberCount).toBe(12);
     });
   });
 

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -13,101 +13,25 @@ const server = setupServer(
       [
         {
           id: 1,
-          userId: 1,
-          author: '황인우',
-          type: '참가자 모집',
-          hits: 100,
+          hits: 334,
+          game: {
+            type: '축구',
+            date: '2022년 10월 19일 13:00~16:00',
+            place: '대전월드컵경기장',
+            currentMemberCount: 16,
+            targetMemberCount: 22,
+          },
         },
         {
           id: 2,
-          userId: 2,
-          author: '전민지',
-          type: '참가자 모집',
-          hits: 10000,
-        },
-      ],
-    ))
-  )),
-  rest.get(`${apiBaseUrl}/images/thumbnail`, (request, response, context) => (
-    response(context.json(
-      [
-        {
-          id: 1,
-          postId: 1,
-          url: 'Image url of Post 1',
-        },
-        {
-          id: 2,
-          postId: 2,
-          url: 'Image url of Post 2',
-        },
-      ],
-    ))
-  )),
-  rest.get(`${apiBaseUrl}/games`, (request, response, context) => (
-    response(context.json(
-      [
-        {
-          id: 1,
-          postId: 1,
-          date: '2022년 11월 9일 09:00~11:00',
-          exercise: '축구',
-          type: '연습경기',
-          level: '아마추어',
-          membersCount: 13,
-          targetMembersCount: 22,
-        },
-        {
-          id: 2,
-          postId: 2,
-          date: '2022년 11월 12일 19:00~22:00',
-          exercise: '야구',
-          type: '경기',
-          level: '선출 경력 1년 이상',
-          membersCount: 8,
-          targetMembersCount: 15,
-        },
-      ],
-    ))
-  )),
-  rest.get(`${apiBaseUrl}/places`, (request, response, context) => (
-    response(context.json(
-      [
-        {
-          id: 1,
-          gameId: 1,
-          name: '상암월드컵경기장',
-        },
-        {
-          id: 2,
-          gameId: 2,
-          name: '고척스카이돔',
-        },
-      ],
-    ))
-  )),
-  rest.get(`${apiBaseUrl}/roles`, (request, response, context) => (
-    response(context.json(
-      [
-        {
-          id: 1,
-          gameId: 1,
-          name: '포지션무관',
-        },
-        {
-          id: 2,
-          gameId: 2,
-          name: '투수',
-        },
-        {
-          id: 3,
-          gameId: 2,
-          name: '야수',
-        },
-        {
-          id: 4,
-          gameId: 2,
-          name: '포수',
+          hits: 10,
+          game: {
+            type: '농구',
+            date: '2022년 10월 20일 15:00~17:00',
+            place: '잠실실내체육관',
+            currentMemberCount: 2,
+            targetMemberCount: 12,
+          },
         },
       ],
     ))


### PR DESCRIPTION
수행한 작업
1. fetchPosts API를 제외한 다른 모든 API의 호출 제거
2. 다른 API에서 가져오던 데이터는 GET posts 요청에서 처리
3. 썸네일 DTO 구성요소 정의 (최소한도)
- id
- 조회수
- 운동
  - 운동 종류
  - 운동 날짜
  - 운동 장소
  - 현재 참가자/총 참가자

회고
최소한도의 구성요소였다라고 한다면 조회수조차도 뺄 수 있었을 것 같다.

예상 뽀모: 2
사용 뽀모: 1