### PR TITLE
운동 게시글 목록 조회 시 AccessToken 기준 버튼 컴포넌트 출력 구분

### DIFF
--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -29,20 +29,37 @@ export default function Posts({ posts }) {
       <Thumbnails>
         {posts.map((post) => (
           <Thumbnail key={post.id}>
-            <p>
-              조회수:
-              {' '}
-              {post.hits}
-            </p>
-            <p>{post.game.type}</p>
-            <p>{post.game.date}</p>
-            <p>{post.game.place}</p>
-            <p>
-              {post.game.currentMemberCount}
-              /
-              {post.game.targetMemberCount}
-              명
-            </p>
+            <div>
+              <p>
+                조회수:
+                {' '}
+                {post.hits}
+              </p>
+              <p>{post.game.type}</p>
+              <p>{post.game.date}</p>
+              <p>{post.game.place}</p>
+              <p>
+                {post.game.currentMemberCount}
+                /
+                {post.game.targetMemberCount}
+                명
+              </p>
+            </div>
+            <div>
+              {post.game.isRegistered ? (
+                <button
+                  type="button"
+                >
+                  신청취소
+                </button>
+              ) : (
+                <button
+                  type="button"
+                >
+                  신청
+                </button>
+              )}
+            </div>
           </Thumbnail>
         ))}
       </Thumbnails>

--- a/src/components/Posts.test.jsx
+++ b/src/components/Posts.test.jsx
@@ -22,6 +22,7 @@ describe('Posts', () => {
           place: '잠실야구장',
           currentMemberCount: 4,
           targetMemberCount: 12,
+          isRegistered: true,
         },
       },
       {
@@ -33,6 +34,7 @@ describe('Posts', () => {
           place: '세종대학교 운동장',
           currentMemberCount: 7,
           targetMemberCount: 8,
+          isRegistered: false,
         },
       },
     ];
@@ -49,6 +51,9 @@ describe('Posts', () => {
       screen.getByText(/2022년 12월 22일 19:00~20:00/);
       screen.getByText(/세종대학교 운동장/);
       screen.getByText(/7/);
+
+      expect(screen.queryAllByText('신청').length).toBe(1);
+      expect(screen.queryAllByText(/신청취소/).length).toBe(1);
     });
   });
 

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -17,7 +17,11 @@ export default class PostApiService {
 
   async fetchPosts() {
     const url = `${apiBaseUrl}/posts`;
-    const { data } = await axios.get(url);
+    const { data } = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
     return data.posts;
   }
 

--- a/src/stores/PostStore.test.js
+++ b/src/stores/PostStore.test.js
@@ -21,13 +21,16 @@ describe('PostStore', () => {
 
   context('API 서버에 게시글 리스트 데이터를 요청할 경우', () => {
     it('백엔드 서버에서 응답으로 전달된 post 리스트를 상태로 저장', async () => {
+      postApiService.setAccessToken('userId 1 is Author');
       await postStore.fetchPosts();
 
       const { posts } = postStore;
 
       expect(posts.length).toBe(2);
       expect(posts[0].hits).toBe(334);
+      expect(posts[0].game.isRegistered).toBe(false);
       expect(posts[1].game.targetMemberCount).toBe(12);
+      expect(posts[1].game.isRegistered).toBe(true);
     });
   });
 

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -8,34 +8,42 @@ import config from './config';
 const { apiBaseUrl } = config;
 
 const server = setupServer(
-  rest.get(`${apiBaseUrl}/posts`, (request, response, context) => (
-    response(context.json(
-      [
-        {
-          id: 1,
-          hits: 334,
-          game: {
-            type: '축구',
-            date: '2022년 10월 19일 13:00~16:00',
-            place: '대전월드컵경기장',
-            currentMemberCount: 16,
-            targetMemberCount: 22,
+  rest.get(`${apiBaseUrl}/posts`, async (request, response, context) => {
+    const accessToken = await request.headers.get('Authorization');
+
+    if (accessToken) {
+      return response(context.json({
+        posts: [
+          {
+            id: 1,
+            hits: 334,
+            game: {
+              type: '축구',
+              date: '2022년 10월 19일 13:00~16:00',
+              place: '대전월드컵경기장',
+              currentMemberCount: 16,
+              targetMemberCount: 22,
+              isRegistered: false,
+            },
           },
-        },
-        {
-          id: 2,
-          hits: 10,
-          game: {
-            type: '농구',
-            date: '2022년 10월 20일 15:00~17:00',
-            place: '잠실실내체육관',
-            currentMemberCount: 2,
-            targetMemberCount: 12,
+          {
+            id: 2,
+            hits: 10,
+            game: {
+              type: '농구',
+              date: '2022년 10월 20일 15:00~17:00',
+              place: '잠실실내체육관',
+              currentMemberCount: 2,
+              targetMemberCount: 12,
+              isRegistered: true,
+            },
           },
-        },
-      ],
-    ))
-  )),
+        ],
+      }));
+    }
+
+    return response(context.status(400));
+  }),
 
   // rest.get(`${apiBaseUrl}/posts/:postId`, async (request, response, context) => {
   //   const { postId } = await request.params;


### PR DESCRIPTION
사용자가 특정 운동에 참가를 신청하지 않았으면 신청 버튼이,
참가를 신청했으면 신청취소 버튼 출력
  
프론트엔드
1. 로컬 스토리지에 사용자 Id를 JWT로 인코딩한 토큰을 저장해서 사용자를 구분
2. fetchPosts() 동작에 로컬 스토리지의 토큰을 전달해서 헤더로 토큰이 전달되게 함
2. 프론트엔드 게시글 응답 데이터 중 game에 isRegistered 추가