### PR TITLE
게시글 상세 정보 UI 컴포넌트 작성

### DIFF
--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import PostGameInformation from './PostGameInformation';
+import PostInformation from './PostInformation';
+import PostMemberInformation from './PostMemberInformation';
+
+const Container = styled.article`
+  
+`;
+
+export default function Post({
+  post,
+  game,
+  members,
+}) {
+  return (
+    <Container>
+      <PostInformation
+        hits={post.hits}
+        authorName={post.authorName}
+        authorPhoneNumber={post.authorPhoneNumber}
+        detail={post.detail}
+      />
+      <PostGameInformation
+        type={game.type}
+        date={game.date}
+        place={game.place}
+        currentMemberCount={game.currentMemberCount}
+        targetMemberCount={game.targetMemberCount}
+      />
+      <PostMemberInformation
+        members={members}
+      />
+      {/* TODO: post.isAuthor를 기준으로
+          PostRegisterButton, PostApplicants? 컴포넌트 구분 */}
+    </Container>
+  );
+}

--- a/src/components/PostGameInformation.jsx
+++ b/src/components/PostGameInformation.jsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+const Container = styled.section`
+  
+`;
+
+export default function PostGameInformation({
+  type,
+  date,
+  place,
+  currentMemberCount,
+  targetMemberCount,
+}) {
+  return (
+    <Container>
+      <p>
+        종목:
+        {' '}
+        {type}
+      </p>
+      <p>
+        날짜:
+        {' '}
+        {date}
+      </p>
+      <p>
+        장소:
+        {' '}
+        {place}
+      </p>
+      <p>
+        참가인원:
+        {' '}
+        {currentMemberCount}
+        /
+        {targetMemberCount}
+        명
+      </p>
+    </Container>
+  );
+}

--- a/src/components/PostGameInformation.test.jsx
+++ b/src/components/PostGameInformation.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import PostGameInformation from './PostGameInformation';
+
+describe('PostGameInformation', () => {
+  const renderPostGameInformation = ({
+    type,
+    date,
+    place,
+    currentMemberCount,
+    targetMemberCount,
+  }) => {
+    render((
+      <PostGameInformation
+        type={type}
+        date={date}
+        place={place}
+        currentMemberCount={currentMemberCount}
+        targetMemberCount={targetMemberCount}
+      />
+    ));
+  };
+
+  context('경기 정보가 전달된 경우', () => {
+    const type = '테니스';
+    const date = '2024년 10월 24일 13:00~16:00';
+    const place = '올림픽공원 테니스경기장';
+    const currentMemberCount = 3;
+    const targetMemberCount = 4;
+
+    it('경기 정보를 출력', () => {
+      renderPostGameInformation({
+        type,
+        date,
+        place,
+        currentMemberCount,
+        targetMemberCount,
+      });
+
+      screen.getByText('종목: 테니스');
+      screen.getByText('날짜: 2024년 10월 24일 13:00~16:00');
+      screen.getByText('장소: 올림픽공원 테니스경기장');
+      screen.getByText('참가인원: 3/4명');
+    });
+  });
+});

--- a/src/components/PostInformation.jsx
+++ b/src/components/PostInformation.jsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+const Container = styled.section`
+  
+`;
+
+export default function PostInformation({
+  hits,
+  authorName,
+  authorPhoneNumber,
+  detail,
+}) {
+  return (
+    <Container>
+      <p>
+        조회수:
+        {' '}
+        {hits}
+      </p>
+      <p>
+        작성자:
+        {' '}
+        {authorName}
+      </p>
+      <p>
+        작성자 연락처:
+        {' '}
+        {authorPhoneNumber}
+      </p>
+      <p>
+        {detail}
+      </p>
+    </Container>
+  );
+}

--- a/src/components/PostInformation.test.jsx
+++ b/src/components/PostInformation.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import PostInformation from './PostInformation';
+
+describe('PostInformation', () => {
+  const renderPostInformation = ({
+    hits,
+    authorName,
+    authorPhoneNumber,
+    detail,
+  }) => {
+    render((
+      <PostInformation
+        hits={hits}
+        authorName={authorName}
+        authorPhoneNumber={authorPhoneNumber}
+        detail={detail}
+      />
+    ));
+  };
+
+  context('게시글 정보가 전달된 경우', () => {
+    const hits = 15;
+    const authorName = '사용자 1';
+    const authorPhoneNumber = '010-1234-5678';
+    const detail = '사용자 1이 쓴 운동 모집 게시글의 내용입니다.';
+
+    it('게시글 정보를 출력', () => {
+      renderPostInformation({
+        hits,
+        authorName,
+        authorPhoneNumber,
+        detail,
+      });
+
+      screen.getByText('조회수: 15');
+      screen.getByText('작성자: 사용자 1');
+      screen.getByText('작성자 연락처: 010-1234-5678');
+      screen.getByText('사용자 1이 쓴 운동 모집 게시글의 내용입니다.');
+    });
+  });
+});

--- a/src/components/PostMemberInformation.jsx
+++ b/src/components/PostMemberInformation.jsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+const Container = styled.article`
+  
+`;
+
+const Member = styled.li`
+  display: flex;
+`;
+
+export default function PostMemberInformation({ members }) {
+  return (
+    <Container>
+      <p>참가자 정보</p>
+      <ul>
+        {members.map((member) => (
+          <Member key={member.id}>
+            <p>{member.name}</p>
+            <p>{member.gender}</p>
+            <p>{member.phoneNumber}</p>
+          </Member>
+        ))}
+      </ul>
+    </Container>
+  );
+}

--- a/src/components/PostMemberInformation.test.jsx
+++ b/src/components/PostMemberInformation.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import PostMemberInformation from './PostMemberInformation';
+
+describe('PostMemberInformation', () => {
+  const renderPostMemberInformation = ({ members }) => {
+    render((
+      <PostMemberInformation
+        members={members}
+      />
+    ));
+  };
+
+  context('경기 정보가 전달된 경우', () => {
+    const members = [
+      {
+        id: 1,
+        name: '조코비치',
+        gender: '남성',
+        phoneNumber: '010-1234-5678',
+      },
+      {
+        id: 2,
+        name: '페더러',
+        gender: '남성',
+        phoneNumber: '010-8765-4321',
+      },
+    ];
+
+    it('경기 정보를 출력', () => {
+      renderPostMemberInformation({ members });
+
+      screen.getByText('참가자 정보');
+      screen.getByText('조코비치');
+      screen.getByText('010-8765-4321');
+      expect(screen.getAllByText('남성').length).toBe(2);
+    });
+  });
+});

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,5 +1,15 @@
+import Post from '../components/Post';
+
 export default function PostPage() {
+  const post = {};
+  const game = {};
+  const members = [];
+
   return (
-    <p>게시글 상세 페이지</p>
+    <Post
+      post={post}
+      game={game}
+      members={members}
+    />
   );
 }

--- a/src/pages/PostPage.test.jsx
+++ b/src/pages/PostPage.test.jsx
@@ -1,0 +1,116 @@
+import {
+  fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import context from 'jest-plugin-context';
+import PostPage from './PostPage';
+
+// let registeredGameId;
+// let registerErrorCodeAndMessage;
+// let registerToGame;
+// jest.mock('../hooks/useRegisterStore', () => () => ({
+//   registeredGameId,
+//   registerErrorCodeAndMessage,
+//   registerToGame,
+// }));
+
+// let cancelParticipateGame;
+// jest.mock('../hooks/useMemberStore', () => () => ({
+//   cancelParticipateGame,
+// }));
+
+describe('PostPage', () => {
+  context('', () => {
+    it('', () => {
+
+    });
+  });
+
+  // function renderPostPage() {
+  //   render((
+  //     <PostPage />
+  //   ));
+  // }
+
+  // context('운동 모집 게시글 상세 조회 페이지가 호출되면', () => {
+  //   post = {
+  //     id: 1,
+  //     hits: 100,
+  //     isAuthor: false,
+  //   };
+  //   game = {
+  //     id: 22,
+  //     type: '축구',
+  //     date: '2022년 12월 19일 08:00~11:00',
+  //     place: '상암월드컵경기장',
+  //     currentMemberCount: 23,
+  //     targetMemberCount: 26,
+  //     isRegistered: false,
+  //   };
+  //   place = {
+  //     id: 1,
+  //     name:
+  //   };
+
+  //   it('운동 모집 게시글 상태를 가져오기 위한 fetchPost 수행', async () => {
+  //     renderPostsPage();
+
+  //     await waitFor(() => {
+  //       expect(fetchPosts).toBeCalled();
+  //     });
+  //   });
+
+  //   context('운동 모집 게시글 리스트 중 하나의 내용을 클릭하면', () => {
+  //     it('운동 게시글 상세 보기로 이동하는 navigate 함수 호출', () => {
+  //       jest.clearAllMocks();
+
+  //       renderPostsPage();
+
+  //       fireEvent.click(screen.getByText('문학야구장'));
+  //       expect(navigate).toBeCalledWith('/posts/2', {
+  //         state: {
+  //           postId: 2,
+  //         },
+  //       });
+  //     });
+  //   });
+
+  //   context('운동 신청 버튼을 누르면', () => {
+  //     const expectedGameId = 22;
+  //     registeredGameId = expectedGameId;
+  //     registerErrorCodeAndMessage = {};
+
+  //     it('운동 신청을 위한 registerToGame 호출 후'
+  //       + '운동 모집 게시글 상태 최신화를 위해 fetchPosts 다시 호출', async () => {
+  //       jest.clearAllMocks();
+  //       registerToGame = jest.fn(() => registeredGameId);
+
+  //       renderPostsPage();
+
+  //       fireEvent.click(screen.getByText('신청'));
+  //       await waitFor(() => {
+  //         expect(registerToGame).toBeCalledWith(expectedGameId);
+  //         expect(registerToGame).toReturnWith(registeredGameId);
+  //         expect(fetchPosts).toBeCalledTimes(2);
+  //       });
+  //     });
+  //   });
+
+  //   context('운동 참가 취소 버튼을 누르면', () => {
+  //     const expectedGameId = 48;
+
+  //     it('운동 참가 취소를 위한 cancelParticipateGame 호출 후'
+  //       + '운동 모집 게시글 상태 최신화를 위해 fetchPosts 다시 호출', async () => {
+  //       jest.clearAllMocks();
+  //       cancelParticipateGame = jest.fn();
+
+  //       renderPostsPage();
+
+  //       fireEvent.click(screen.getByText('신청취소'));
+  //       await waitFor(() => {
+  //         expect(cancelParticipateGame).toBeCalledWith(expectedGameId);
+  //         expect(fetchPosts).toBeCalledTimes(2);
+  //       });
+  //     });
+  //   });
+  // });
+});

--- a/steps_file.js
+++ b/steps_file.js
@@ -13,6 +13,8 @@ module.exports = function () {
       this.amOnPage(`${backdoorBaseUrl}/empty-members`);
     },
 
+    // Operations
+
     // Seeing UI Components
     seeHeader() {
       this.see('SMASH');

--- a/tests/cancel_register_game_test.js
+++ b/tests/cancel_register_game_test.js
@@ -6,14 +6,6 @@ Scenario('사용자가 참가를 취소하는 경우', async ({ I }) => {
   I.emptyMembers();
   I.setupMembers();
 
-  // userId: 1
-  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
-    + '.eyJ1c2VySWQiOjF9'
-    + '.jNVVoRzUDIDEfED_sh3-5zsNkihSbOtuV-fu4RUH3hw';
-  await I.executeScript((setToken) => {
-    localStorage.setItem('token', setToken);
-  }, token);
-
   // When
   I.amOnPage('/posts/list');
   I.see('1/24명');

--- a/tests/posts_test.js
+++ b/tests/posts_test.js
@@ -1,6 +1,6 @@
 Feature('게시글 목록 보기');
 
-// TODO: 각 테스트가 독립적이므로 Before로 구분!!!!
+// TODO: 각 테스트가 독립적이므로 Before로 구분!!!
 
 Scenario('등록된 게시글이 없는 경우', ({ I }) => {
   // Given
@@ -13,21 +13,13 @@ Scenario('등록된 게시글이 없는 경우', ({ I }) => {
   I.see('등록된 게시물이 존재하지 않습니다.');
 });
 
-Scenario('동록된 게시글이 존재하는 경우', async ({ I }) => {
+Scenario('동록된 게시글이 존재하는 경우', ({ I }) => {
   // Given
   I.setupPosts();
 
-  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
-  + '.eyJ1c2VySWQiOjF9'
-  + '.jNVVoRzUDIDEfED_sh3-5zsNkihSbOtuV-fu4RUH3hw';
-  await I.executeScript((setToken) => {
-    localStorage.setItem('token', setToken);
-  }, token);
-
   // When
-  I.amOnPage('/posts/list');
-  // I.wait(2);
-  I.waitForElement('[posts]', 2);
+  I.amOnPage('/');
+  I.click('운동 찾기');
 
   // Then
   I.see('축구');


### PR DESCRIPTION
UI에서는 게시글 목록에서는 볼 수 없었던 추가적인 정보들이 출력됨
- Post
  - 작성자명
  - 작성자 연락처
  - 게시글 상세 내용
- Member
  - 이름
  - 성별
  - 연락처

게시글 목록 보기와 마찬가지로 신청, 신청취소 버튼이 출력되게 하고
참가자와 작성자를 구분하기 위해 post에 전달받는 데이터로 isAuthor 추가할 계획이었으나...

작업 도중 계획 변경
- 작업 단위를 구분하기 위해 일단 isAuthor까지는 받지만, UI에서 출력될 내용이 구분되는 것은 다른 작업으로 분리
  (사진의 빨간색, 파란색 작업을 별도의 작업으로 분리)
  
![Image](https://user-images.githubusercontent.com/50052512/201868489-849c9b75-398c-4440-9dc7-ffe7fb951e61.jpeg)
  
예상 뽀모 4
실제 뽀모 6