### PR TITLE
임시 로그인 기능

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,5 +44,6 @@ module.exports = {
     'key-spacing': ['error', { mode: 'strict' }],
     'arrow-spacing': ['error', { before: true, after: true }],
     'react/prop-types': 'off',
+    'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
   },
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,8 @@ import { Route, Routes } from 'react-router-dom';
 import styled from 'styled-components';
 import { Reset } from 'styled-reset';
 
+import { useLocalStorage } from 'usehooks-ts';
+import { useEffect } from 'react';
 import { postApiService } from './services/PostApiService';
 import { registerApiService } from './services/RegisterApiService';
 import { memberApiService } from './services/MemberApiService';
@@ -29,10 +31,13 @@ const Wrapper = styled.div`
 `;
 
 export default function App() {
-  const accessToken = localStorage.getItem('accessToken');
-  postApiService.setAccessToken(accessToken);
-  registerApiService.setAccessToken(accessToken);
-  memberApiService.setAccessToken(accessToken);
+  const [accessToken] = useLocalStorage('accessToken', '');
+
+  useEffect(() => {
+    postApiService.setAccessToken(accessToken);
+    registerApiService.setAccessToken(accessToken);
+    memberApiService.setAccessToken(accessToken);
+  }, [accessToken]);
 
   return (
     <Container>

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -1,22 +1,89 @@
-import { render, screen } from '@testing-library/react';
+import {
+  fireEvent, render, screen,
+} from '@testing-library/react';
 
 import context from 'jest-plugin-context';
 import { MemoryRouter } from 'react-router-dom';
 
 import Header from './Header';
 
+const changeUserId = jest.fn();
+let login;
+jest.mock('../hooks/useUserStore', () => () => ({
+  changeUserId,
+  login,
+}));
+
 describe('Header', () => {
+  const renderHeader = () => {
+    render((
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    ));
+  };
+
   context('헤더 컴포넌트 확인 시', () => {
-    it('애플리케이션 이름, 운동 선택하기, 사이드바 메뉴 펼치기 버튼 존재', () => {
-      render((
-        <MemoryRouter>
-          <Header />
-        </MemoryRouter>
-      ));
+    it('애플리케이션 이름 출력', () => {
+      renderHeader();
 
       screen.getByText(/SMASH/);
-      screen.getByText(/운동 선택하기/);
-      screen.getByText(/사이드바 메뉴/);
+    });
+
+    context('로그인이 되어있지 않은 경우', () => {
+      it('User 식별자 입력란, 로그인 버튼 출력', () => {
+        localStorage.setItem('accessToken', '');
+        renderHeader();
+
+        screen.getByLabelText('User Id:');
+        screen.getByText('로그인');
+      });
+
+      context('값을 입력할 경우', () => {
+        it('입력한 user Id 값을 변경하는 UserStore의 changeUserId 함수 호출', () => {
+          localStorage.setItem('accessToken', '');
+          renderHeader();
+
+          fireEvent.change(screen.getByLabelText(/User Id/), {
+            target: { value: 2 },
+          });
+          expect(changeUserId).toBeCalledWith(2);
+        });
+      });
+
+      context('로그인 버튼을 누를 경우', () => {
+        const expectedAccessToken = 'VALID ACCESS TOKEN';
+
+        it('accessToken을 받아오기 위한 UserStore의 login 함수 호출', () => {
+          login = jest.fn(() => expectedAccessToken);
+          localStorage.setItem('accessToken', '');
+          renderHeader();
+
+          fireEvent.click(screen.getByText('로그인'));
+
+          expect(login).toBeCalled();
+        });
+      });
+    });
+
+    context('로그인이 되어있는 경우', () => {
+      it('로그아웃 버튼 출력', () => {
+        localStorage.setItem('accessToken', JSON.stringify('TOKEN'));
+        renderHeader();
+
+        screen.getByText('로그아웃');
+      });
+
+      context('로그아웃 버튼을 누를 경우', () => {
+        it('accessToken을 비움', () => {
+          localStorage.setItem('accessToken', JSON.stringify('TOKEN'));
+          renderHeader();
+
+          fireEvent.click(screen.getByText('로그아웃'));
+          const accessToken = localStorage.getItem('accessToken');
+          expect(JSON.parse(accessToken)).toBe('');
+        });
+      });
     });
   });
 });

--- a/src/hooks/useUserStore.js
+++ b/src/hooks/useUserStore.js
@@ -1,0 +1,6 @@
+import { userStore } from '../stores/UserStore';
+import useStore from './useStore';
+
+export default function useUserStore() {
+  return useStore(userStore);
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,11 @@
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { postApiService } from './services/PostApiService';
+
+const data = localStorage.getItem('accessToken');
+const accessToken = JSON.parse(data);
+postApiService.setAccessToken(accessToken);
 
 const container = document.getElementById('app');
 const root = ReactDOM.createRoot(container);

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useLocalStorage } from 'usehooks-ts';
+
 import usePostStore from '../hooks/usePostStore';
 import useRegisterStore from '../hooks/useRegisterStore';
 import useMemberStore from '../hooks/useMemberStore';
@@ -10,13 +12,15 @@ import Posts from '../components/Posts';
 export default function PostsPage() {
   const navigate = useNavigate();
 
+  const [accessToken] = useLocalStorage('accessToken', '');
+
   const postStore = usePostStore();
   const registerStore = useRegisterStore();
   const memberStore = useMemberStore();
 
   useEffect(() => {
     postStore.fetchPosts();
-  }, []);
+  }, [accessToken]);
 
   const { posts, postsErrorMessage } = postStore;
 

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -16,6 +16,7 @@ export default class PostApiService {
   }
 
   async fetchPosts() {
+    console.log(this.accessToken);
     const url = `${apiBaseUrl}/posts`;
     const { data } = await axios.get(url, {
       headers: {

--- a/src/services/UserApiService.js
+++ b/src/services/UserApiService.js
@@ -1,0 +1,17 @@
+/* eslint-disable class-methods-use-this */
+
+import axios from 'axios';
+
+import config from '../config';
+
+const { apiBaseUrl } = config;
+
+export default class UserApiService {
+  async postSession(userId) {
+    const url = `${apiBaseUrl}/session`;
+    const { data } = await axios.post(url, { userId });
+    return data;
+  }
+}
+
+export const userApiService = new UserApiService();

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -1,0 +1,31 @@
+import { userApiService } from '../services/UserApiService';
+import Store from './Store';
+
+export default class UserStore extends Store {
+  constructor() {
+    super();
+
+    this.userId = '';
+    this.accessToken = '';
+    this.loginErrorMessage = '';
+  }
+
+  changeUserId(userId) {
+    this.userId = userId;
+    this.publish();
+  }
+
+  async login() {
+    try {
+      const data = await userApiService.postSession(this.userId);
+      this.accessToken = data.accessToken;
+      return this.accessToken;
+    } catch (error) {
+      const { errorMessage } = error.response.data;
+      this.loginErrorMessage = errorMessage;
+      return '';
+    }
+  }
+}
+
+export const userStore = new UserStore();

--- a/src/stores/UserStore.test.js
+++ b/src/stores/UserStore.test.js
@@ -1,0 +1,65 @@
+import context from 'jest-plugin-context';
+import UserStore from './UserStore';
+
+import { userApiService } from '../services/UserApiService';
+
+describe('UserStore', () => {
+  let userStore;
+  let spyPublish;
+  let spyPostSession;
+  let spyLogin;
+
+  beforeEach(() => {
+    userStore = new UserStore();
+    spyPublish = jest.spyOn(userStore, 'publish');
+    spyPostSession = jest.spyOn(userApiService, 'postSession');
+    spyLogin = jest.spyOn(userStore, 'login');
+    jest.clearAllMocks();
+  });
+
+  context('userId의 상태를 변경시키는 함수가 호출되면', () => {
+    it('userId의 상태를 변경하고 publish', () => {
+      expect(userStore.userId).toBe('');
+      userStore.changeUserId(2);
+      expect(userStore.userId).toBe(2);
+      expect(spyPublish).toBeCalled();
+    });
+  });
+
+  context('존재하는 userId로 로그인 함수가 호출되면', () => {
+    it('userApiService의 postSession을 호출하면서 저장된 userId의 상태를 전달해'
+      + '반환되는 Token 값을 상태로 저장 후 반환', async () => {
+      userStore.changeUserId(10);
+      await userStore.login();
+      expect(spyPostSession).toBeCalledWith(10);
+      expect(userStore.accessToken).toBe('TOKEN');
+
+      expect(spyLogin).toReturn();
+      // TODO: accessToken까지 들고 return하는지까지는 확인할 수는 없는 걸까?
+      // expect(spyLogin).toReturnWith();
+    });
+  });
+
+  context('userId를 입력하지 않은 채로 로그인 함수가 호출되면', () => {
+    it('에러 메세지를 상태로 저장 후 반환', async () => {
+      await userStore.login();
+      expect(userStore.loginErrorMessage).toBe('user Id를 입력해주세요. (200)');
+    });
+  });
+
+  context('존재하지 않는 userId로 로그인 함수가 호출되면', () => {
+    it('에러 메세지를 상태로 저장 후 반환', async () => {
+      userStore.changeUserId(4444);
+      await userStore.login();
+      expect(userStore.loginErrorMessage).toBe('존재하지 않는 user Id 입니다. (201)');
+    });
+  });
+
+  context('userId로 로그인 함수가 호출되었는데 인코딩 과정에서 문제가 발생했으면', () => {
+    it('에러 메세지를 상태로 저장 후 반환', async () => {
+      userStore.changeUserId(1234);
+      await userStore.login();
+      expect(userStore.loginErrorMessage).toBe('user Id 인코딩 과정에서 문제가 발생했습니다. (202)');
+    });
+  });
+});

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -109,6 +109,44 @@ const postTestServer = setupServer(
 
     return response(context.status(400));
   }),
+
+  rest.post(`${apiBaseUrl}/session`, async (request, response, context) => {
+    const { userId } = await request.json();
+
+    if (userId === 10) {
+      return response(
+        context.status(201),
+        context.json({
+          accessToken: 'TOKEN',
+        }),
+      );
+    }
+
+    if (userId === '') {
+      return response(
+        context.status(400),
+        context.json({
+          errorMessage: 'user Id를 입력해주세요. (200)',
+        }),
+      );
+    }
+
+    if (userId === 1234) {
+      return response(
+        context.status(400),
+        context.json({
+          errorMessage: 'user Id 인코딩 과정에서 문제가 발생했습니다. (202)',
+        }),
+      );
+    }
+
+    return response(
+      context.status(400),
+      context.json({
+        errorMessage: '존재하지 않는 user Id 입니다. (201)',
+      }),
+    );
+  }),
 );
 
 export default postTestServer;

--- a/steps_file.js
+++ b/steps_file.js
@@ -4,22 +4,28 @@ module.exports = function () {
   return actor({
     // Setup Databases
     clearPosts() {
-      this.amOnPage(`${backdoorBaseUrl}/empty-posts`);
+      this.amOnPage(`${backdoorBaseUrl}/clear-posts`);
     },
     setupPosts() {
       this.amOnPage(`${backdoorBaseUrl}/setup-posts`);
     },
-    emptyMembers() {
-      this.amOnPage(`${backdoorBaseUrl}/empty-members`);
+    clearMembers() {
+      this.amOnPage(`${backdoorBaseUrl}/clear-members`);
+    },
+    setupMembers() {
+      this.amOnPage(`${backdoorBaseUrl}/setup-members`);
     },
 
     // Operations
+    login({ userId }) {
+      this.amOnPage('/');
+      this.fillField('User Id:', userId);
+      this.click('로그인');
+    },
 
     // Seeing UI Components
     seeHeader() {
       this.see('SMASH');
-      this.see('운동 선택하기');
-      this.see('사이드바 메뉴');
     },
   });
 };


### PR DESCRIPTION
인수 테스트 통과 시 명시적으로 accessToken을 설정해주기 위해
임시 로그인 기능을 작성해 인수 테스트 상에서 accessToken을 가질 수 있도록 임시 로그인 구현
  
index.jsx
- localStorage에서 getItem으로 accessToken을 받아와 JSON.parse
- apiService에 setAccessToken

App.jsx
- useLocalStorage hook으로 accessToken을 확인할 수 있게 하는데, Effect Hook 내에서 accessToken의 변화가 감지되면 apiService에 setAccessToken

Header 컴포넌트의 사이드바 메뉴 버튼 삭제
- 운동 선택하기 버튼을 User Id 입력, 로그인 버튼 / 로그아웃 버튼으로 대체

UserStore.js
- UserApiService의 postSession에 userId를 담아 호출, 반환되는 인코딩된 token 값 저장 후 배포

UserApiService.js
- userId를 백엔드 서버에 POST 요청으로 전달, accessToken을 응답으로 받음

예상 뽀모 3
실제 뽀모 9 (프론트엔드, 백엔드 통합 기준)

이슈
- 예외 케이스와 그에 대한 테스트 코드를 작성하는 과정에 예상보다 많은 뽀모가 소요되었음
  
완전 로그인은 일요일에 리팩터링해서 완성하는 것으로 작업에 추가