### PR TITLE
게시글 목록 조회, 운동 참가 신청, 운동 참가 취소 인수 테스트 작성 및 리팩터링

### DIFF
--- a/tests/cancel_register_game_test.js
+++ b/tests/cancel_register_game_test.js
@@ -3,13 +3,14 @@ Feature('운동 참가 취소');
 Scenario('사용자가 참가를 취소하는 경우', async ({ I }) => {
   // Given
   I.setupPosts();
-  I.emptyMembers();
+  I.clearMembers();
   I.setupMembers();
+  I.login({ userId: 1 });
 
   // When
   I.amOnPage('/posts/list');
   I.see('1/24명');
-  I.click('[type=button]:nth-child(1)', '신청취소');
+  I.click('신청취소', { css: 'section button:first-child' });
 
   // Then
   I.see('0/24명');

--- a/tests/posts_test.js
+++ b/tests/posts_test.js
@@ -5,6 +5,7 @@ Feature('게시글 목록 보기');
 Scenario('등록된 게시글이 없는 경우', ({ I }) => {
   // Given
   I.clearPosts();
+  I.login({ userId: 1 });
 
   // When
   I.amOnPage('/posts/list');
@@ -16,6 +17,7 @@ Scenario('등록된 게시글이 없는 경우', ({ I }) => {
 Scenario('동록된 게시글이 존재하는 경우', ({ I }) => {
   // Given
   I.setupPosts();
+  I.login({ userId: 1 });
 
   // When
   I.amOnPage('/');
@@ -31,6 +33,6 @@ Scenario('동록된 게시글이 존재하는 경우', ({ I }) => {
   I.see('배구');
   I.see('2022년 11월 14일 15:00~17:00');
   I.see('장충체육관');
-  I.see('2/12명');
+  I.see('1/12명');
   I.see('조회수: 5593');
 });

--- a/tests/register_game_test.js
+++ b/tests/register_game_test.js
@@ -3,19 +3,13 @@ Feature('운동 참가 신청');
 Scenario('사용자가 참가를 신청하는 경우', async ({ I }) => {
   // Given
   I.setupPosts();
-  I.emptyMembers();
-  // userId: 1
-  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
-    + '.eyJ1c2VySWQiOjF9'
-    + '.jNVVoRzUDIDEfED_sh3-5zsNkihSbOtuV-fu4RUH3hw';
-  await I.executeScript((setToken) => {
-    localStorage.setItem('token', setToken);
-  }, token);
+  I.clearMembers();
+  I.login({ userId: 1 });
 
   // When
   I.amOnPage('/posts/list');
   I.see('0/24명');
-  I.click('[type=button]:nth-child(1)', '신청');
+  I.click('신청', { css: 'section button:first-child' });
 
   // Then
   I.see('1/24명');


### PR DESCRIPTION
게시글 목록 조회, 운동 참가 신청, 운동 참가 취소 기능에 대한 인수 테스트 작성

이슈
요소가 존재하지 않을 시 출력되는 Guard Clause에서 화면이 멈추고 넘어가지 않는 문제가 발생해
wait와 관련된 Codeceptjs의 함수들을 찾아 적용해보았으나 실패
일단 기대하는 테스트 결과만 작성하는 것으로 보류

원인
- Access Token이 없는 상태에서 게시글 목록 조회를 시도하고 있었음
  따라서 백엔드 서버에서 인가 오류가 발생했던 것임
  인수 테스트에서 Access Token을 설정해주기 위해 인수 테스트에서 직접 setAccessToken을 설정해주는 방법을 시도했으나,
  인수 테스트의 방향성과 맞지 않다고 판단해 임시 로그인을 구현하는 방법으로 선회
  (인수 테스트는 개발자가 아닌 사람도 이해할 수 있어야 하는데,
  setAccessToken이나 token 문자열은 개발자가 아닌 사람은 이해할 수 없음)

임시 로그인 기능을 추가해 인수 테스트 통과 완료
임시 로그인 기능은 완전 로그인 기능으로 리팩터링 예정

예상 뽀모 5
사용 뽀모 4