### PR TITLE
게시글 상세 정보 상태 관리, API 요청 양식 정의

### DIFF
--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -3,6 +3,7 @@ import {
 } from '@testing-library/react';
 
 import context from 'jest-plugin-context';
+import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
 import Header from './Header';
@@ -40,28 +41,32 @@ describe('Header', () => {
       });
 
       context('값을 입력할 경우', () => {
-        it('입력한 user Id 값을 변경하는 UserStore의 changeUserId 함수 호출', () => {
+        it('입력한 user Id 값을 변경하는 UserStore의 changeUserId 함수 호출', async () => {
           localStorage.setItem('accessToken', '');
           renderHeader();
 
+          // await act(() => {
           fireEvent.change(screen.getByLabelText(/User Id/), {
             target: { value: 2 },
           });
           expect(changeUserId).toBeCalledWith(2);
+          // });
         });
       });
 
       context('로그인 버튼을 누를 경우', () => {
         const expectedAccessToken = 'VALID ACCESS TOKEN';
 
-        it('accessToken을 받아오기 위한 UserStore의 login 함수 호출', () => {
+        it('accessToken을 받아오기 위한 UserStore의 login 함수 호출', async () => {
           login = jest.fn(() => expectedAccessToken);
           localStorage.setItem('accessToken', '');
           renderHeader();
 
+          // await act(() => {
           fireEvent.click(screen.getByText('로그인'));
 
           expect(login).toBeCalled();
+          // });
         });
       });
     });
@@ -75,13 +80,15 @@ describe('Header', () => {
       });
 
       context('로그아웃 버튼을 누를 경우', () => {
-        it('accessToken을 비움', () => {
+        it('accessToken을 비움', async () => {
           localStorage.setItem('accessToken', JSON.stringify('TOKEN'));
           renderHeader();
 
+          // await act(() => {
           fireEvent.click(screen.getByText('로그아웃'));
           const accessToken = localStorage.getItem('accessToken');
           expect(JSON.parse(accessToken)).toBe('');
+          // });
         });
       });
     });

--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -12,6 +12,14 @@ export default function Post({
   game,
   members,
 }) {
+  if (!Object.keys(post).length
+    || !Object.keys(game).length
+    || !members.length) {
+    return (
+      <p>정보를 불러오고 있습니다...</p>
+    );
+  }
+
   return (
     <Container>
       <PostInformation

--- a/src/components/Post.test.jsx
+++ b/src/components/Post.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import Post from './Post';
+
+describe('Post', () => {
+  const renderPost = ({
+    post,
+    game,
+    members,
+  }) => {
+    render((
+      <Post
+        post={post}
+        game={game}
+        members={members}
+      />
+    ));
+  };
+
+  context('게시글 정보가 아직 전달되지 않은 경우', () => {
+    const post = {};
+    const game = {};
+    const members = [];
+
+    it('게시글 정보를 불러오고 있다는 메세지 출력', () => {
+      renderPost({
+        post,
+        game,
+        members,
+      });
+
+      screen.getByText('정보를 불러오고 있습니다...');
+    });
+  });
+});

--- a/src/hooks/useGameStore.js
+++ b/src/hooks/useGameStore.js
@@ -1,0 +1,6 @@
+import { gameStore } from '../stores/GameStore';
+import useStore from './useStore';
+
+export default function useGameStore() {
+  return useStore(gameStore);
+}

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,9 +1,35 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useLocalStorage } from 'usehooks-ts';
 import Post from '../components/Post';
+import usePostStore from '../hooks/usePostStore';
+import useGameStore from '../hooks/useGameStore';
+import useMemberStore from '../hooks/useMemberStore';
 
 export default function PostPage() {
-  const post = {};
-  const game = {};
-  const members = [];
+  const [accessToken] = useLocalStorage('accessToken', '');
+
+  const location = useLocation();
+
+  const postId = location.state !== null
+    ? location.state.postId
+    : Number(location.pathname.split('/')[2]);
+
+  const postStore = usePostStore();
+  const gameStore = useGameStore();
+  const memberStore = useMemberStore();
+
+  useEffect(() => {
+    postStore.fetchPost(postId);
+    const gameId = gameStore.fetchGame(postId);
+    if (gameId) {
+      memberStore.fetchMembers(gameId);
+    }
+  }, [accessToken]);
+
+  const { post } = postStore;
+  const { game } = gameStore;
+  const { members } = memberStore;
 
   return (
     <Post

--- a/src/pages/PostPage.test.jsx
+++ b/src/pages/PostPage.test.jsx
@@ -1,116 +1,96 @@
 import {
-  fireEvent, render, screen, waitFor,
+  render, waitFor,
 } from '@testing-library/react';
 import context from 'jest-plugin-context';
 import PostPage from './PostPage';
 
-// let registeredGameId;
-// let registerErrorCodeAndMessage;
-// let registerToGame;
-// jest.mock('../hooks/useRegisterStore', () => () => ({
-//   registeredGameId,
-//   registerErrorCodeAndMessage,
-//   registerToGame,
-// }));
+let postId;
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    state: {
+      postId,
+    },
+  }),
+}));
 
-// let cancelParticipateGame;
-// jest.mock('../hooks/useMemberStore', () => () => ({
-//   cancelParticipateGame,
-// }));
+let post;
+const fetchPost = jest.fn();
+jest.mock('../hooks/usePostStore', () => () => ({
+  post,
+  fetchPost,
+}));
+
+let game;
+let fetchGame;
+jest.mock('../hooks/useGameStore', () => () => ({
+  game,
+  fetchGame,
+}));
+
+let members;
+const fetchMembers = jest.fn();
+jest.mock('../hooks/useMemberStore', () => () => ({
+  members,
+  fetchMembers,
+}));
 
 describe('PostPage', () => {
-  context('', () => {
-    it('', () => {
+  function renderPostPage() {
+    render((
+      <PostPage />
+    ));
+  }
 
+  context('운동 모집 게시글 상세 정보 페이지에 접속하면', () => {
+    postId = 1;
+
+    post = {
+      id: 1,
+      hits: 15,
+      authorName: '작성자명',
+      authorPhoneNumber: '010-6877-2291',
+      detail: '게시글 상세 정보 내용입니다.',
+      isAuthor: false,
+    };
+    game = {
+      id: 1,
+      type: '농구',
+      date: '2022년 12월 23일 20:00~22:00',
+      place: '인천삼산체육관',
+      currentMemberCount: 2,
+      targetMemberCount: 12,
+      isRegistered: true,
+    };
+    members = [
+      {
+        id: 1,
+        name: '사용자 1',
+        gender: '남성',
+        phoneNumber: '010-1234-5678',
+      },
+      {
+        id: 2,
+        name: '사용자 2',
+        gender: '남성',
+        phoneNumber: '010-8765-4321',
+      },
+    ];
+
+    it('운동 모집 게시글 상세 정보 상태들을 PostStore, '
+      + 'GameStore, MemberStore에서 순차적으로 fetch', async () => {
+      jest.clearAllMocks();
+      const expectedPostId = 1;
+      const expectedGameId = 1;
+      fetchGame = jest.fn(() => expectedGameId);
+
+      renderPostPage();
+
+      await waitFor(() => {
+        expect(fetchPost).toBeCalledWith(expectedPostId);
+        expect(fetchGame).toBeCalledWith(expectedPostId);
+        expect(fetchGame).toReturnWith(expectedGameId);
+        expect(fetchMembers).toBeCalledWith(expectedGameId);
+      });
     });
   });
-
-  // function renderPostPage() {
-  //   render((
-  //     <PostPage />
-  //   ));
-  // }
-
-  // context('운동 모집 게시글 상세 조회 페이지가 호출되면', () => {
-  //   post = {
-  //     id: 1,
-  //     hits: 100,
-  //     isAuthor: false,
-  //   };
-  //   game = {
-  //     id: 22,
-  //     type: '축구',
-  //     date: '2022년 12월 19일 08:00~11:00',
-  //     place: '상암월드컵경기장',
-  //     currentMemberCount: 23,
-  //     targetMemberCount: 26,
-  //     isRegistered: false,
-  //   };
-  //   place = {
-  //     id: 1,
-  //     name:
-  //   };
-
-  //   it('운동 모집 게시글 상태를 가져오기 위한 fetchPost 수행', async () => {
-  //     renderPostsPage();
-
-  //     await waitFor(() => {
-  //       expect(fetchPosts).toBeCalled();
-  //     });
-  //   });
-
-  //   context('운동 모집 게시글 리스트 중 하나의 내용을 클릭하면', () => {
-  //     it('운동 게시글 상세 보기로 이동하는 navigate 함수 호출', () => {
-  //       jest.clearAllMocks();
-
-  //       renderPostsPage();
-
-  //       fireEvent.click(screen.getByText('문학야구장'));
-  //       expect(navigate).toBeCalledWith('/posts/2', {
-  //         state: {
-  //           postId: 2,
-  //         },
-  //       });
-  //     });
-  //   });
-
-  //   context('운동 신청 버튼을 누르면', () => {
-  //     const expectedGameId = 22;
-  //     registeredGameId = expectedGameId;
-  //     registerErrorCodeAndMessage = {};
-
-  //     it('운동 신청을 위한 registerToGame 호출 후'
-  //       + '운동 모집 게시글 상태 최신화를 위해 fetchPosts 다시 호출', async () => {
-  //       jest.clearAllMocks();
-  //       registerToGame = jest.fn(() => registeredGameId);
-
-  //       renderPostsPage();
-
-  //       fireEvent.click(screen.getByText('신청'));
-  //       await waitFor(() => {
-  //         expect(registerToGame).toBeCalledWith(expectedGameId);
-  //         expect(registerToGame).toReturnWith(registeredGameId);
-  //         expect(fetchPosts).toBeCalledTimes(2);
-  //       });
-  //     });
-  //   });
-
-  //   context('운동 참가 취소 버튼을 누르면', () => {
-  //     const expectedGameId = 48;
-
-  //     it('운동 참가 취소를 위한 cancelParticipateGame 호출 후'
-  //       + '운동 모집 게시글 상태 최신화를 위해 fetchPosts 다시 호출', async () => {
-  //       jest.clearAllMocks();
-  //       cancelParticipateGame = jest.fn();
-
-  //       renderPostsPage();
-
-  //       fireEvent.click(screen.getByText('신청취소'));
-  //       await waitFor(() => {
-  //         expect(cancelParticipateGame).toBeCalledWith(expectedGameId);
-  //         expect(fetchPosts).toBeCalledTimes(2);
-  //       });
-  //     });
-  //   });
-  // });
 });

--- a/src/services/GameApiService.js
+++ b/src/services/GameApiService.js
@@ -6,7 +6,7 @@ import config from '../config';
 
 const { apiBaseUrl } = config;
 
-export default class PostApiService {
+export default class GameApiService {
   constructor() {
     this.accessToken = '';
   }
@@ -15,18 +15,8 @@ export default class PostApiService {
     this.accessToken = accessToken;
   }
 
-  async fetchPosts() {
-    const url = `${apiBaseUrl}/posts`;
-    const { data } = await axios.get(url, {
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
-      },
-    });
-    return data;
-  }
-
-  async fetchPost(postId) {
-    const url = `${apiBaseUrl}/posts/${postId}`;
+  async fetchGame(postId) {
+    const url = `${apiBaseUrl}/games/${postId}`;
     const { data } = await axios.get(url, {
       headers: {
         Authorization: `Bearer ${this.accessToken}`,
@@ -36,4 +26,4 @@ export default class PostApiService {
   }
 }
 
-export const postApiService = new PostApiService();
+export const gameApiService = new GameApiService();

--- a/src/services/MemberApiService.js
+++ b/src/services/MemberApiService.js
@@ -15,6 +15,16 @@ export default class MemberApiService {
     this.accessToken = accessToken;
   }
 
+  async fetchMembers(gameId) {
+    const url = `${apiBaseUrl}/members/${gameId}`;
+    const { data } = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
+    return data;
+  }
+
   async cancelParticipateGame(gameId) {
     const url = `${apiBaseUrl}/members/games/${gameId}`;
 

--- a/src/stores/GameStore.js
+++ b/src/stores/GameStore.js
@@ -1,0 +1,25 @@
+import { gameApiService } from '../services/GameApiService';
+import Store from './Store';
+
+export default class GameStore extends Store {
+  constructor() {
+    super();
+
+    this.game = {};
+    this.gameErrorMessage = '';
+  }
+
+  async fetchGame(postId) {
+    try {
+      const data = await gameApiService.fetchGame(postId);
+      this.game = data.game;
+      this.publish();
+    } catch (error) {
+      const { errorMessage } = error.response.data;
+      this.gameErrorMessage = errorMessage;
+      this.publish();
+    }
+  }
+}
+
+export const gameStore = new GameStore();

--- a/src/stores/GameStore.test.js
+++ b/src/stores/GameStore.test.js
@@ -1,0 +1,23 @@
+import context from 'jest-plugin-context';
+import GameStore from './GameStore';
+
+import { gameApiService } from '../services/GameApiService';
+
+describe('GameStore', () => {
+  const gameStore = new GameStore();
+
+  context('API 서버에 게시글의 게임 상세 정보 데이터를 요청할 경우', () => {
+    const postId = 1;
+
+    it('백엔드 서버에서 응답으로 전달된 단일 game을 상태로 저장', async () => {
+      gameApiService.setAccessToken('userId 1');
+      await gameStore.fetchGame(postId);
+
+      const { game, gameErrorMessage } = gameStore;
+
+      expect(Object.keys(game).length).toBe(7);
+      expect(game.place).toBe('서울숲탁구클럽');
+      expect(gameErrorMessage).toBeFalsy();
+    });
+  });
+});

--- a/src/stores/MemberStore.js
+++ b/src/stores/MemberStore.js
@@ -1,9 +1,26 @@
+/* eslint-disable class-methods-use-this */
+
 import { memberApiService } from '../services/MemberApiService';
 import Store from './Store';
 
 export default class MemberStore extends Store {
   constructor() {
     super();
+
+    this.members = [];
+    this.membersErrorMessage = '';
+  }
+
+  async fetchMembers(gameId) {
+    try {
+      const data = await memberApiService.fetchMembers(gameId);
+      this.members = data.members;
+      this.publish();
+    } catch (error) {
+      const { errorMessage } = error.response.data;
+      this.membersErrorMessage = errorMessage;
+      this.publish();
+    }
   }
 
   async cancelParticipateGame(gameId) {

--- a/src/stores/MemberStore.test.js
+++ b/src/stores/MemberStore.test.js
@@ -6,6 +6,22 @@ import { memberApiService } from '../services/MemberApiService';
 describe('MemberStore', () => {
   const memberStore = new MemberStore();
 
+  context('API 서버에 게시글 게임의 참가자 상세 정보 데이터를 요청할 경우', () => {
+    const gameId = 1;
+
+    it('백엔드 서버에서 응답으로 전달된 member 컬렉션을 상태로 저장', async () => {
+      memberApiService.setAccessToken('userId 1');
+      await memberStore.fetchMembers(gameId);
+
+      const { members, membersErrorMessage } = memberStore;
+
+      expect(members.length).toBe(2);
+      expect(members[0].name).toBe('작성자');
+      expect(members[1].gender).toBe('여성');
+      expect(membersErrorMessage).toBeFalsy();
+    });
+  });
+
   context('운동 참가 취소 API를 요청할 경우', () => {
     it('memberApiService API 요청을 호출', async () => {
       memberApiService.setAccessToken('userId 1');

--- a/src/stores/PostStore.js
+++ b/src/stores/PostStore.js
@@ -10,6 +10,9 @@ export default class PostStore extends Store {
 
     this.posts = [];
     this.postsErrorMessage = '';
+
+    this.post = {};
+    this.postErrorMessage = '';
   }
 
   async fetchPosts() {
@@ -20,6 +23,18 @@ export default class PostStore extends Store {
     } catch (error) {
       const { errorMessage } = error.response.data;
       this.postsErrorMessage = errorMessage;
+      this.publish();
+    }
+  }
+
+  async fetchPost(postId) {
+    try {
+      const data = await postApiService.fetchPost(postId);
+      this.post = data.post;
+      this.publish();
+    } catch (error) {
+      const { errorMessage } = error.response.data;
+      this.postErrorMessage = errorMessage;
       this.publish();
     }
   }

--- a/src/stores/PostStore.test.js
+++ b/src/stores/PostStore.test.js
@@ -41,4 +41,19 @@ describe('PostStore', () => {
       expect(postsErrorMessage).toBe('주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.');
     });
   });
+
+  context('API 서버에 게시글 상세 정보 데이터를 요청할 경우', () => {
+    const postId = 1;
+
+    it('백엔드 서버에서 응답으로 전달된 단일 post를 상태로 저장', async () => {
+      postApiService.setAccessToken('userId 1');
+      await postStore.fetchPost(postId);
+
+      const { post, postErrorMessage } = postStore;
+
+      expect(Object.keys(post).length).toBe(6);
+      expect(post.authorPhoneNumber).toBe('010-1111-2222');
+      expect(postErrorMessage).toBeFalsy();
+    });
+  });
 });

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -8,145 +8,258 @@ import config from './config';
 const { apiBaseUrl } = config;
 
 const postTestServer = setupServer(
-  rest.get(`${apiBaseUrl}/posts`, async (request, response, context) => {
-    const accessToken = await request.headers.get('Authorization')
-      .substring('bearer '.length);
+  // fetchPosts
+  rest.get(
+    `${apiBaseUrl}/posts`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
 
-    if (accessToken === 'userId 1') {
-      return response(context.json({
-        posts: [
-          {
-            id: 1,
-            hits: 334,
-            game: {
-              type: '축구',
-              date: '2022년 10월 19일 13:00~16:00',
-              place: '대전월드컵경기장',
-              currentMemberCount: 16,
-              targetMemberCount: 22,
-              isRegistered: false,
+      if (accessToken === 'userId 1') {
+        return response(context.json({
+          posts: [
+            {
+              id: 1,
+              hits: 334,
+              game: {
+                type: '축구',
+                date: '2022년 10월 19일 13:00~16:00',
+                place: '대전월드컵경기장',
+                currentMemberCount: 16,
+                targetMemberCount: 22,
+                isRegistered: false,
+              },
             },
-          },
-          {
-            id: 2,
-            hits: 10,
+            {
+              id: 2,
+              hits: 10,
+              game: {
+                type: '농구',
+                date: '2022년 10월 20일 15:00~17:00',
+                place: '잠실실내체육관',
+                currentMemberCount: 2,
+                targetMemberCount: 12,
+                isRegistered: true,
+              },
+            },
+          ],
+        }));
+      }
+
+      if (accessToken === 'userId 4') {
+        return response(
+          context.status(400),
+          context.json({
+            errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
+          }),
+        );
+      }
+
+      return response(context.status(400));
+    },
+  ),
+
+  // registerToGame
+  rest.post(
+    `${apiBaseUrl}/registers/games/:gameId`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
+      const { gameId } = await request.params;
+
+      if (gameId === '1' && accessToken === 'userId 1') {
+        return response(context.json({
+          gameId: 1,
+        }));
+      }
+
+      if (gameId === '100' && accessToken === 'userId 1') {
+        return response(
+          context.status(400),
+          context.json({
+            errorCode: 100,
+            errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
+          }),
+        );
+      }
+
+      if (gameId === '1' && accessToken === 'already registered userId 2') {
+        return response(
+          context.status(400),
+          context.json({
+            errorCode: 101,
+            errorMessage: '이미 신청이 완료된 운동입니다.',
+          }),
+        );
+      }
+
+      if (gameId === '1' && accessToken === 'not existed userId 3') {
+        return response(
+          context.status(400),
+          context.json({
+            errorCode: 102,
+            errorMessage: '주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다.',
+          }),
+        );
+      }
+
+      return response(context.status(400));
+    },
+  ),
+
+  // cancelParticipateGame
+  rest.delete(
+    `${apiBaseUrl}/members/games/:gameId`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization');
+      const { gameId } = await request.params;
+
+      if (gameId === '1' && accessToken) {
+        return response(context.status(204));
+      }
+
+      return response(context.status(400));
+    },
+  ),
+
+  // login
+  rest.post(
+    `${apiBaseUrl}/session`,
+    async (request, response, context) => {
+      const { userId } = await request.json();
+
+      if (userId === 10) {
+        return response(
+          context.status(201),
+          context.json({
+            accessToken: 'TOKEN',
+          }),
+        );
+      }
+
+      if (userId === '') {
+        return response(
+          context.status(400),
+          context.json({
+            errorMessage: 'user Id를 입력해주세요. (200)',
+          }),
+        );
+      }
+
+      if (userId === 1234) {
+        return response(
+          context.status(400),
+          context.json({
+            errorMessage: 'user Id 인코딩 과정에서 문제가 발생했습니다. (202)',
+          }),
+        );
+      }
+
+      return response(
+        context.status(400),
+        context.json({
+          errorMessage: '존재하지 않는 user Id 입니다. (201)',
+        }),
+      );
+    },
+  ),
+
+  // fetchPost
+  rest.get(
+    `${apiBaseUrl}/posts/:postId`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
+      const { postId } = await request.params;
+
+      if (postId === '1' && accessToken === 'userId 1') {
+        return response(
+          context.status(200),
+          context.json({
+            post: {
+              id: 1,
+              hits: 223,
+              authorName: '작성자',
+              authorPhoneNumber: '010-1111-2222',
+              detail: '점심먹고 가볍게 탁구하실분?',
+              isAuthor: true,
+            },
+          }),
+        );
+      }
+
+      return response(
+        context.status(400),
+      );
+    },
+  ),
+
+  // fetchGame
+  rest.get(
+    `${apiBaseUrl}/games/:postId`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
+      const { postId } = await request.params;
+
+      if (postId === '1' && accessToken === 'userId 1') {
+        return response(
+          context.status(200),
+          context.json({
             game: {
-              type: '농구',
-              date: '2022년 10월 20일 15:00~17:00',
-              place: '잠실실내체육관',
+              id: 1,
+              type: '탁구',
+              date: '2022년 10월 19일 12:30~13:30',
+              place: '서울숲탁구클럽',
               currentMemberCount: 2,
-              targetMemberCount: 12,
+              targetMemberCount: 4,
               isRegistered: true,
             },
-          },
-        ],
-      }));
-    }
+          }),
+        );
+      }
 
-    if (accessToken === 'userId 4') {
       return response(
         context.status(400),
-        context.json({
-          errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
-        }),
       );
-    }
+    },
+  ),
 
-    return response(context.status(400));
-  }),
+  // fetchMembers
+  rest.get(
+    `${apiBaseUrl}/members/:gameId`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
+      const { gameId } = await request.params;
 
-  rest.post(`${apiBaseUrl}/registers/games/:gameId`, async (request, response, context) => {
-    const accessToken = await request.headers.get('Authorization')
-      .substring('bearer '.length);
-    const { gameId } = await request.params;
+      if (gameId === '1' && accessToken === 'userId 1') {
+        return response(
+          context.status(200),
+          context.json({
+            members: [
+              {
+                id: 1,
+                name: '작성자',
+                gender: '남성',
+                phoneNumber: '010-1111-2222',
+              },
+              {
+                id: 2,
+                name: '사용자 2',
+                gender: '여성',
+                phoneNumber: '010-9999-9999',
+              },
+            ],
+          }),
+        );
+      }
 
-    if (gameId === '1' && accessToken === 'userId 1') {
-      return response(context.json({
-        gameId: 1,
-      }));
-    }
-
-    if (gameId === '100' && accessToken === 'userId 1') {
       return response(
         context.status(400),
-        context.json({
-          errorCode: 100,
-          errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
-        }),
       );
-    }
-
-    if (gameId === '1' && accessToken === 'already registered userId 2') {
-      return response(
-        context.status(400),
-        context.json({
-          errorCode: 101,
-          errorMessage: '이미 신청이 완료된 운동입니다.',
-        }),
-      );
-    }
-
-    if (gameId === '1' && accessToken === 'not existed userId 3') {
-      return response(
-        context.status(400),
-        context.json({
-          errorCode: 102,
-          errorMessage: '주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다.',
-        }),
-      );
-    }
-
-    return response(context.status(400));
-  }),
-
-  rest.delete(`${apiBaseUrl}/members/games/:gameId`, async (request, response, context) => {
-    const accessToken = await request.headers.get('Authorization');
-    const { gameId } = await request.params;
-
-    if (gameId === '1' && accessToken) {
-      return response(context.status(204));
-    }
-
-    return response(context.status(400));
-  }),
-
-  rest.post(`${apiBaseUrl}/session`, async (request, response, context) => {
-    const { userId } = await request.json();
-
-    if (userId === 10) {
-      return response(
-        context.status(201),
-        context.json({
-          accessToken: 'TOKEN',
-        }),
-      );
-    }
-
-    if (userId === '') {
-      return response(
-        context.status(400),
-        context.json({
-          errorMessage: 'user Id를 입력해주세요. (200)',
-        }),
-      );
-    }
-
-    if (userId === 1234) {
-      return response(
-        context.status(400),
-        context.json({
-          errorMessage: 'user Id 인코딩 과정에서 문제가 발생했습니다. (202)',
-        }),
-      );
-    }
-
-    return response(
-      context.status(400),
-      context.json({
-        errorMessage: '존재하지 않는 user Id 입니다. (201)',
-      }),
-    );
-  }),
+    },
+  ),
 );
 
 export default postTestServer;


### PR DESCRIPTION
요청을 순차적으로 수행
- 먼저 postId를 이용해 Post의 정보를 요청
- 그 다음 post의 postId를 이용해 Game의 정보를 요청
- 그 다음 game의 gameId를 이용해 Members의 정보를 요청
  
fetch해온 정보들은 Store에 따로따로 저장하되,
컴포넌트에 전달할 때는 필요에 따라 요소를 나눠서 전달할 수도 있음
일단은 신청자, 작성자 구분하지 않고 내용만 전달하도록 구현
  
PostPage가 상태를 전달받는 Store
- PostStore
  > PostApiService
- GameStore
  > GameApiService 
- MemberStore
  > MemberApiService

예상 뽀모 7
실제 뽀모 7

회고
- 단일 객체가 내용을 가지고 있는지를 빡세게 검증하기보다는
  Object.keys(객체).length로 객체의 key 값의 길이가 일치하는지 검증하고
  내용 일치는 그 중 하나만 골라서 검증하는 방식으로 진행
- 아직은 내용 출력 외에 CUD와 관련된 로직이 없기 때문에
  fetch하는 내용이나 검증 과정 자체는 다른 리소스에 관련된 Store를 하나 만들고
  그걸 복붙해서 만드는 식에 가까웠지만 (그래서 뽀모 시간을 줄일 수 있지 않을까 생각했지만)
  리소스를 미리 써놓고 했음에도 화면을 오고 가는 시간이 상당히 걸렸다.