### PR TITLE
미신청자/신청자/참가자/작성자별 출력 컴포넌트 구분

### DIFF
--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -3,7 +3,6 @@ import {
 } from '@testing-library/react';
 
 import context from 'jest-plugin-context';
-import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
 import Header from './Header';

--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 import PostGameInformation from './PostGameInformation';
 import PostInformation from './PostInformation';
-import PostMemberInformation from './PostMemberInformation';
+import PostMemberInformation from './PostGameMembersInformation';
+import PostRegisterButton from './PostRegisterButton';
+import PostGameApplicantsInformation from './PostGameApplicantsInformation';
 
 const Container = styled.article`
   margin-inline: 10em;
@@ -19,9 +21,27 @@ export default function Post({
   post,
   game,
   members,
+  applicants,
+  handleClickRegister,
+  handleClickRegisterCancel,
+  handleClickParticipateCancel,
+  acceptRegister,
+  rejectRegister,
 }) {
   const onClickBackward = () => {
     navigateToBackward();
+  };
+
+  const onClickRegister = () => {
+    handleClickRegister(game.id);
+  };
+
+  const onClickRegisterCancel = () => {
+    handleClickRegisterCancel(game.registerId);
+  };
+
+  const onClickParticipateCancel = () => {
+    handleClickParticipateCancel(game.registerId);
   };
 
   if (!post || !game || !members
@@ -56,8 +76,20 @@ export default function Post({
       <PostMemberInformation
         members={members}
       />
-      {/* TODO: post.isAuthor를 기준으로
-          PostRegisterButton, PostApplicants? 컴포넌트 구분 */}
+      {post.isAuthor ? (
+        <PostGameApplicantsInformation
+          applicants={applicants}
+          acceptRegister={acceptRegister}
+          rejectRegister={rejectRegister}
+        />
+      ) : (
+        <PostRegisterButton
+          registerStatus={game.registerStatus}
+          onClickRegister={onClickRegister}
+          onClickRegisterCancel={onClickRegisterCancel}
+          onClickParticipateCancel={onClickParticipateCancel}
+        />
+      )}
     </Container>
   );
 }

--- a/src/components/Post.test.jsx
+++ b/src/components/Post.test.jsx
@@ -3,8 +3,12 @@ import context from 'jest-plugin-context';
 import Post from './Post';
 
 describe('Post', () => {
+  const navigateToBackward = jest.fn();
+  const handleClickRegister = jest.fn();
+  const handleClickRegisterCancel = jest.fn();
+  const handleClickParticipateCancel = jest.fn();
+
   const renderPost = ({
-    navigateToBackward,
     post,
     game,
     members,
@@ -15,6 +19,9 @@ describe('Post', () => {
         post={post}
         game={game}
         members={members}
+        handleClickRegister={handleClickRegister}
+        handleClickRegisterCancel={handleClickRegisterCancel}
+        handleClickParticipateCancel={handleClickParticipateCancel}
       />
     ));
   };
@@ -35,23 +42,24 @@ describe('Post', () => {
     });
   });
 
-  context('게시글 정보가 출력될 때 뒤로가기 버튼을 누른 경우', () => {
+  context('게시글 정보가 출력될 때 뒤로가기 버튼을 누르면', () => {
     const post = {
       id: 1,
       hits: 223,
       authorName: '작성자',
       authorPhoneNumber: '010-1111-2222',
       detail: '점심먹고 가볍게 탁구하실분?',
-      isAuthor: true,
+      isAuthor: false,
     };
     const game = {
       id: 1,
       type: '탁구',
       date: '2022년 10월 19일 12:30~13:30',
       place: '서울숲탁구클럽',
-      currentMemberCount: 2,
+      currentMemberCount: 1,
       targetMemberCount: 4,
-      isRegistered: true,
+      registerId: -1,
+      registerStatus: 'none',
     };
     const members = [
       {
@@ -60,18 +68,10 @@ describe('Post', () => {
         gender: '남성',
         phoneNumber: '010-1111-2222',
       },
-      {
-        id: 2,
-        name: '사용자 2',
-        gender: '여성',
-        phoneNumber: '010-9999-9999',
-      },
     ];
-    const navigateToBackward = jest.fn();
 
-    it('뒤로가기로 이동하는 navigate 함수 호출', () => {
+    it('뒤로가기 navigate 함수를 호출하는 핸들러 함수 호출', () => {
       renderPost({
-        navigateToBackward,
         post,
         game,
         members,
@@ -79,6 +79,141 @@ describe('Post', () => {
 
       fireEvent.click(screen.getByText('⬅️'));
       expect(navigateToBackward).toBeCalled();
+    });
+  });
+
+  context('게시글에 참가 신청 버튼이 출력되는 상태에서'
+    + '사용자가 게시글의 게임에 참가 신청 버튼을 누르면', () => {
+    const post = {
+      id: 1,
+      hits: 223,
+      authorName: '작성자',
+      authorPhoneNumber: '010-1111-2222',
+      detail: '가을 북한산 단풍 구경 모임입니다.',
+      isAuthor: false,
+    };
+    const game = {
+      id: 11,
+      type: '등산',
+      date: '2022년 10월 20일 07:00~14:00',
+      place: '북한산우이역',
+      currentMemberCount: 1,
+      targetMemberCount: 4,
+      registerId: -1,
+      registerStatus: 'none',
+    };
+    const members = [
+      {
+        id: 1,
+        name: '작성자',
+        gender: '남성',
+        phoneNumber: '010-1111-2222',
+      },
+    ];
+
+    it('해당 게임에 참가를 신청하는 운동 참가 신청 핸들러 함수 호출', () => {
+      renderPost({
+        post,
+        game,
+        members,
+      });
+
+      fireEvent.click(screen.getByText('신청'));
+      expect(handleClickRegister).toBeCalledWith(11);
+    });
+  });
+
+  context('게시글에 참가 신청 취소 버튼이 출력되는 상태에서'
+    + '사용자가 게시글의 게임에 참가 신청 취소 버튼을 누르면', () => {
+    const post = {
+      id: 1,
+      hits: 223,
+      authorName: '작성자',
+      authorPhoneNumber: '010-9999-9999',
+      detail: '아라서해갑문 인증센터 >> 여주보 인증센터 당일치기 라이딩입니다.',
+      isAuthor: false,
+    };
+    const game = {
+      id: 11,
+      type: '자전거',
+      date: '2022년 10월 26일 08:00~15:00',
+      place: '아라서해갑문 인증센터',
+      currentMemberCount: 2,
+      targetMemberCount: 4,
+      registerId: 5,
+      registerStatus: 'processing',
+    };
+    const members = [
+      {
+        id: 1,
+        name: '작성자',
+        gender: '남성',
+        phoneNumber: '010-9999-9999',
+      },
+      {
+        id: 5,
+        name: '자전거 하루에 200km타는 사람',
+        gender: '남성',
+        phoneNumber: '010-6666-6666',
+      },
+    ];
+
+    it('해당 게임 참가 신청을 취소하는 운동 참가 신청 취소 핸들러 함수 호출', () => {
+      renderPost({
+        post,
+        game,
+        members,
+      });
+
+      fireEvent.click(screen.getByText('신청취소'));
+      expect(handleClickRegisterCancel).toBeCalledWith(5);
+    });
+  });
+
+  context('게시글에 참가 취소 버튼이 출력되는 상태에서'
+    + '사용자가 게시글의 게임에 참가 취소 버튼을 누르면', () => {
+    const post = {
+      id: 1,
+      hits: 223,
+      authorName: '작성자',
+      authorPhoneNumber: '010-9999-9999',
+      detail: '예시 쓰는것도 쉽지 않네요',
+      isAuthor: false,
+    };
+    const game = {
+      id: 11,
+      type: '예시 운동',
+      date: '2022년 99월 99일 99:00~99:99',
+      place: '예시 장소',
+      currentMemberCount: 2,
+      targetMemberCount: 2000,
+      registerId: 10,
+      registerStatus: 'accepted',
+    };
+    const members = [
+      {
+        id: 1,
+        name: '작성자',
+        gender: '여성',
+        phoneNumber: '010-9999-9999',
+      },
+      {
+        id: 10,
+        name: '참가하는 사람 이름',
+        gender: '여성',
+        phoneNumber: '010-1234-5678',
+      },
+    ];
+
+    it('해당 게임 참가 신청을 취소하는 운동 참가 신청 취소 핸들러 함수 호출', () => {
+      renderPost({
+        post,
+        game,
+        members,
+      });
+
+      fireEvent.click(screen.getByText('참가취소'));
+      expect(handleClickParticipateCancel).toBeCalledWith(10);
     });
   });
 });

--- a/src/components/PostGameApplicantsInformation.jsx
+++ b/src/components/PostGameApplicantsInformation.jsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+
+const Container = styled.section`
+  
+`;
+
+const Applicant = styled.li`
+  display: flex;
+`;
+
+export default function PostGameApplicantsInformation({
+  applicants,
+  acceptRegister,
+  rejectRegister,
+}) {
+  const handleClickAcceptRegister = (applicantId) => {
+    acceptRegister(applicantId);
+  };
+
+  const handleClickRejectRegister = (applicantId) => {
+    rejectRegister(applicantId);
+  };
+
+  if (!applicants) {
+    return (
+      <p>정보를 불러오고 있습니다...</p>
+    );
+  }
+
+  if (applicants.length === 0) {
+    return (
+      <p>신청자가 없습니다.</p>
+    );
+  }
+
+  return (
+    <Container>
+      <p>신청자 정보</p>
+      <ul>
+        {applicants.map((applicant) => (
+          <Applicant key={applicant.id}>
+            <p>{applicant.name}</p>
+            <p>{applicant.gender}</p>
+            <p>{applicant.phoneNumber}</p>
+            <button
+              type="button"
+              onClick={() => handleClickAcceptRegister(applicant.id)}
+            >
+              수락
+            </button>
+            <button
+              type="button"
+              onClick={() => handleClickRejectRegister(applicant.id)}
+            >
+              거절
+            </button>
+          </Applicant>
+        ))}
+      </ul>
+    </Container>
+  );
+}

--- a/src/components/PostGameApplicantsInformation.test.jsx
+++ b/src/components/PostGameApplicantsInformation.test.jsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import PostGameApplicantsInformation from './PostGameApplicantsInformation';
+
+describe('PostGameApplicantsInformation', () => {
+  const acceptRegister = jest.fn();
+  const rejectRegister = jest.fn();
+
+  const renderPostGameApplicantsInformation = ({ applicants }) => {
+    render((
+      <PostGameApplicantsInformation
+        applicants={applicants}
+        acceptRegister={acceptRegister}
+        rejectRegister={rejectRegister}
+      />
+    ));
+  };
+
+  context('게시글에 신청자가 없는 경우', () => {
+    const applicants = [];
+
+    it('신청 버튼 출력', () => {
+      renderPostGameApplicantsInformation({ applicants });
+
+      screen.getByText('신청자가 없습니다.');
+    });
+  });
+
+  context('게시글에 신청자가 있는 경우', () => {
+    const applicants = [
+      {
+        id: 1,
+        name: '전민지',
+        gender: '여성',
+        phoneNumber: '010-0000-0000',
+      },
+      {
+        id: 2,
+        name: '조승준',
+        gender: '남성',
+        phoneNumber: '010-1212-1212',
+      },
+      {
+        id: 3,
+        name: '노성환',
+        gender: '남성',
+        phoneNumber: '010-9876-5432',
+      },
+    ];
+
+    it('각 신청자 정보 및 수락/거절 버튼 출력', () => {
+      renderPostGameApplicantsInformation({ applicants });
+
+      screen.getByText('신청자 정보');
+      screen.getByText('전민지');
+      expect(screen.getAllByText('남성').length).toBe(2);
+      screen.getByText('010-9876-5432');
+      expect(screen.getAllByText('수락').length).toBe(3);
+      expect(screen.getAllByText('거절').length).toBe(3);
+    });
+  });
+
+  context('특정 신청자에 대해 수락 버튼을 누르면', () => {
+    const applicants = [
+      {
+        id: 1,
+        name: '전민지',
+        gender: '여성',
+        phoneNumber: '010-0000-0000',
+      },
+    ];
+
+    it('참가 신청을 수락하는 핸들러 함수 호출', () => {
+      renderPostGameApplicantsInformation({ applicants });
+
+      fireEvent.click(screen.getByText('수락'));
+      const expectedRegisterId = 1;
+      expect(acceptRegister).toBeCalledWith(expectedRegisterId);
+    });
+  });
+
+  context('특정 신청자에 대해 거절 버튼을 누르면', () => {
+    const applicants = [
+      {
+        id: 2,
+        name: '조승준',
+        gender: '남성',
+        phoneNumber: '010-2222-2222',
+      },
+    ];
+
+    it('참가 신청을 거절하는 핸들러 함수 호출', () => {
+      renderPostGameApplicantsInformation({ applicants });
+
+      fireEvent.click(screen.getByText('거절'));
+      const expectedRegisterId = 2;
+      expect(rejectRegister).toBeCalledWith(expectedRegisterId);
+    });
+  });
+});

--- a/src/components/PostGameMembersInformation.jsx
+++ b/src/components/PostGameMembersInformation.jsx
@@ -8,7 +8,7 @@ const Member = styled.li`
   display: flex;
 `;
 
-export default function PostMemberInformation({ members }) {
+export default function PostGameMembersInformation({ members }) {
   if (members.length === 0) {
     return (
       <p>참가자가 없습니다.</p>

--- a/src/components/PostGameMembersInformation.test.jsx
+++ b/src/components/PostGameMembersInformation.test.jsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import context from 'jest-plugin-context';
-import PostMemberInformation from './PostMemberInformation';
+import PostGameMembersInformation from './PostGameMembersInformation';
 
-describe('PostMemberInformation', () => {
-  const renderPostMemberInformation = ({ members }) => {
+describe('PostGameMembersInformation', () => {
+  const renderPostGameMembersInformation = ({ members }) => {
     render((
-      <PostMemberInformation
+      <PostGameMembersInformation
         members={members}
       />
     ));
@@ -28,7 +28,7 @@ describe('PostMemberInformation', () => {
     ];
 
     it('경기 정보를 출력', () => {
-      renderPostMemberInformation({ members });
+      renderPostGameMembersInformation({ members });
 
       screen.getByText('참가자 정보');
       screen.getByText('조코비치');

--- a/src/components/PostRegisterButton.jsx
+++ b/src/components/PostRegisterButton.jsx
@@ -1,0 +1,40 @@
+export default function PostRegisterButton({
+  registerStatus,
+  onClickRegister,
+  onClickRegisterCancel,
+  onClickParticipateCancel,
+}) {
+  console.log(registerStatus);
+
+  if (registerStatus === 'none') {
+    return (
+      <button
+        type="button"
+        onClick={onClickRegister}
+      >
+        신청
+      </button>
+    );
+  }
+
+  if (registerStatus === 'processing') {
+    return (
+      <button
+        type="button"
+        onClick={onClickRegisterCancel}
+      >
+        신청취소
+      </button>
+    );
+  }
+
+  // if (registerStatus === 'accepted')
+  return (
+    <button
+      type="button"
+      onClick={onClickParticipateCancel}
+    >
+      참가취소
+    </button>
+  );
+}

--- a/src/components/PostRegisterButton.test.jsx
+++ b/src/components/PostRegisterButton.test.jsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import PostRegisterButton from './PostRegisterButton';
+
+describe('PostRegisterButton', () => {
+  const onClickRegister = jest.fn();
+  const onClickRegisterCancel = jest.fn();
+  const onClickParticipateCancel = jest.fn();
+
+  const renderPostRegisterButton = ({ registerStatus }) => {
+    render((
+      <PostRegisterButton
+        registerStatus={registerStatus}
+        onClickRegister={onClickRegister}
+        onClickRegisterCancel={onClickRegisterCancel}
+        onClickParticipateCancel={onClickParticipateCancel}
+      />
+    ));
+  };
+
+  context('사용자가 게시글의 게임에 참가 신청을 하지 않았거나, 취소했거나, 거절당했었을 경우', () => {
+    const registerStatus = 'none';
+
+    it('신청 버튼 출력', () => {
+      renderPostRegisterButton({ registerStatus });
+
+      screen.getByText('신청');
+    });
+
+    context('신청 버튼을 클릭하면', () => {
+      it('운동 참가 신청 핸들러 함수 호출', () => {
+        renderPostRegisterButton({ registerStatus });
+
+        fireEvent.click(screen.getByText('신청'));
+        expect(onClickRegister).toBeCalled();
+      });
+    });
+  });
+
+  context('사용자가 게시글의 게임에 참가 신청을 한 상태인 경우', () => {
+    const registerStatus = 'processing';
+
+    it('신청취소 버튼 출력', () => {
+      renderPostRegisterButton({ registerStatus });
+
+      screen.getByText('신청취소');
+    });
+
+    context('신청취소 버튼을 클릭하면', () => {
+      it('운동 참가 신청 취소 핸들러 함수 호출', () => {
+        renderPostRegisterButton({ registerStatus });
+
+        fireEvent.click(screen.getByText('신청취소'));
+        expect(onClickRegisterCancel).toBeCalled();
+      });
+    });
+  });
+
+  context('사용자가 게시글의 게임에 참가하는 상태인 경우', () => {
+    const registerStatus = 'accepted';
+
+    it('참가취소 버튼 출력', () => {
+      renderPostRegisterButton({ registerStatus });
+
+      screen.getByText('참가취소');
+    });
+
+    context('참가취소 버튼을 클릭하면', () => {
+      it('운동 참가 취소 핸들러 함수 호출', () => {
+        renderPostRegisterButton({ registerStatus });
+
+        fireEvent.click(screen.getByText('참가취소'));
+        expect(onClickParticipateCancel).toBeCalled();
+      });
+    });
+  });
+});

--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -23,13 +23,14 @@ const Thumbnail = styled.li`
 `;
 
 export default function Posts({
-  navigateToBackward,
   posts,
+  navigateToBackward,
   navigateToPost,
+  registerToGame,
+  cancelRegisterToGame,
+  cancelParticipateToGame,
   postsErrorMessage,
   registerErrorCodeAndMessage,
-  registerToGame,
-  cancelRegisterGame,
 }) {
   const onClickBackward = () => {
     navigateToBackward();
@@ -71,13 +72,29 @@ export default function Posts({
               targetMemberCount={post.game.targetMemberCount}
               onClickPost={() => onClickPost(post.id)}
             />
-            <PostsRegisterButton
-              gameId={post.game.id}
-              isRegistered={post.game.isRegistered}
-              registerToGame={registerToGame}
-              cancelRegisterGame={cancelRegisterGame}
-              registerErrorCodeAndMessage={registerErrorCodeAndMessage}
-            />
+            {
+              post.isAuthor ? (
+                null
+              ) : (
+                <>
+                  <PostsRegisterButton
+                    gameId={post.game.id}
+                    registerId={post.game.registerId}
+                    registerStatus={post.game.registerStatus}
+                    registerToGame={registerToGame}
+                    cancelRegisterToGame={cancelRegisterToGame}
+                    cancelParticipateToGame={cancelParticipateToGame}
+                  />
+                  {registerErrorCodeAndMessage.message ? (
+                    <p>
+                      {registerErrorCodeAndMessage.message}
+                    </p>
+                  ) : (
+                    null
+                  )}
+                </>
+              )
+            }
           </Thumbnail>
         ))}
       </Thumbnails>

--- a/src/components/Posts.test.jsx
+++ b/src/components/Posts.test.jsx
@@ -6,7 +6,8 @@ describe('Posts', () => {
   const navigateToBackward = jest.fn();
   const navigateToPost = jest.fn();
   const registerToGame = jest.fn();
-  const cancelRegisterGame = jest.fn();
+  const cancelRegisterToGame = jest.fn();
+  const cancelParticipateToGame = jest.fn();
 
   const renderPosts = ({
     posts,
@@ -15,13 +16,14 @@ describe('Posts', () => {
   }) => {
     render((
       <Posts
-        navigateToBackward={navigateToBackward}
         posts={posts}
+        navigateToBackward={navigateToBackward}
         navigateToPost={navigateToPost}
+        registerToGame={registerToGame}
+        cancelRegisterToGame={cancelRegisterToGame}
+        cancelParticipateToGame={cancelParticipateToGame}
         postsErrorMessage={postsErrorMessage}
         registerErrorCodeAndMessage={registerErrorCodeAndMessage}
-        registerToGame={registerToGame}
-        cancelRegisterGame={cancelRegisterGame}
       />
     ));
   };
@@ -29,7 +31,7 @@ describe('Posts', () => {
   context('등록된 게시글이 존재하지 않는 경우', () => {
     const posts = [];
     const postsErrorMessage = '';
-    const registerErrorCodeAndMessage = '';
+    const registerErrorCodeAndMessage = {};
 
     it('게시물 미존재 안내 메세지 출력', () => {
       renderPosts({
@@ -45,7 +47,7 @@ describe('Posts', () => {
   context('게임이 찾아지지 않은 에러가 발생한 경우', () => {
     const posts = [];
     const postsErrorMessage = '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.';
-    const registerErrorCodeAndMessage = '';
+    const registerErrorCodeAndMessage = {};
 
     it('에러 메세지 출력', () => {
       renderPosts({
@@ -63,18 +65,20 @@ describe('Posts', () => {
       {
         id: 1,
         hits: 334,
+        isAuthor: false,
         game: {
           type: '배드민턴',
           date: '2022년 10월 24일 13:00~16:00',
           place: '올림픽공원 핸드볼경기장',
           currentMemberCount: 4,
           targetMemberCount: 5,
-          isRegistered: false,
+          registerId: 10,
+          registerStatus: 'accepted',
         },
       },
     ];
     const postsErrorMessage = '';
-    const registerErrorCodeAndMessage = '';
+    const registerErrorCodeAndMessage = {};
 
     it('뒤로가기 버튼을 누를 시 뒤로가기로 이동하는 navigate 함수 호출', () => {
       renderPosts({
@@ -97,6 +101,54 @@ describe('Posts', () => {
       fireEvent.click(screen.getByText('배드민턴'));
       const expectedPostId = 1;
       expect(navigateToPost).toBeCalledWith(expectedPostId);
+    });
+
+    it('사용자가 버튼을 클릭하고 나서 에러가 전달되었을 시 에러 메세지를 출력', () => {
+      const codeAndMessage = {
+        code: 100,
+        message: '에러 메세지 내용입니다.',
+      };
+
+      renderPosts({
+        posts,
+        postsErrorMessage,
+        registerErrorCodeAndMessage: codeAndMessage,
+      });
+
+      screen.getByText(/에러 메세지 내용입니다./);
+    });
+  });
+
+  context('등록된 게시물이 있는데 작성자가 사용자 자신일 경우', () => {
+    const posts = [
+      {
+        id: 1,
+        hits: 334,
+        isAuthor: true,
+        game: {
+          type: '주짓수',
+          date: '2022년 10월 31일 08:00~11:00',
+          place: '팀 레드 주짓수&MMA',
+          currentMemberCount: 4,
+          targetMemberCount: 5,
+          registerId: 11,
+          registerStatus: 'accepted',
+        },
+      },
+    ];
+    const postsErrorMessage = '';
+    const registerErrorCodeAndMessage = {};
+
+    it('해당 게시글 리스트 제목 옆에 신청/취소/참가취소 버튼이 나타나지 않음', () => {
+      renderPosts({
+        posts,
+        postsErrorMessage,
+        registerErrorCodeAndMessage,
+      });
+
+      expect(screen.queryByText('신청')).toBeNull();
+      expect(screen.queryByText('신청취소')).toBeNull();
+      expect(screen.queryByText('참가취소')).toBeNull();
     });
   });
 });

--- a/src/components/PostsRegisterButton.jsx
+++ b/src/components/PostsRegisterButton.jsx
@@ -1,48 +1,52 @@
-import styled from 'styled-components';
-
-const Container = styled.section`
-  
-`;
-
 export default function PostsRegisterButton({
   gameId,
-  isRegistered,
+  registerId,
+  registerStatus,
   registerToGame,
-  cancelRegisterGame,
-  registerErrorCodeAndMessage,
+  cancelRegisterToGame,
+  cancelParticipateToGame,
 }) {
-  const handleRegisterToGameClick = (id) => {
-    registerToGame(id);
+  const handleClickRegister = (targetGameId) => {
+    registerToGame(targetGameId);
   };
 
-  const handleCancelRegisterGameClick = (id) => {
-    cancelRegisterGame(id);
+  const handleClickCancelRegister = (targetRegisterId) => {
+    cancelRegisterToGame(targetRegisterId);
   };
 
+  const handleClickCancelParticipate = (targetRegisterId) => {
+    cancelParticipateToGame(targetRegisterId);
+  };
+
+  if (registerStatus === 'none') {
+    return (
+      <button
+        type="button"
+        onClick={() => handleClickRegister(gameId)}
+      >
+        신청
+      </button>
+    );
+  }
+
+  if (registerStatus === 'processing') {
+    return (
+      <button
+        type="button"
+        onClick={() => handleClickCancelRegister(registerId)}
+      >
+        신청취소
+      </button>
+    );
+  }
+
+  // if (registerStatus === 'accepted')
   return (
-    <Container>
-      {isRegistered ? (
-        <button
-          type="button"
-          onClick={() => handleCancelRegisterGameClick(gameId)}
-        >
-          신청취소
-        </button>
-      ) : (
-        <button
-          type="button"
-          onClick={() => handleRegisterToGameClick(gameId)}
-        >
-          신청
-        </button>
-      )}
-      {registerErrorCodeAndMessage.message ? (
-        <p>
-          {registerErrorCodeAndMessage.message}
-        </p>
-      ) : (
-        null
-      )}
-    </Container>
+    <button
+      type="button"
+      onClick={() => handleClickCancelParticipate(registerId)}
+    >
+      참가취소
+    </button>
   );
 }

--- a/src/components/PostsRegisterButton.test.jsx
+++ b/src/components/PostsRegisterButton.test.jsx
@@ -4,78 +4,76 @@ import PostsRegisterButton from './PostsRegisterButton';
 
 describe('PostsRegisterButton', () => {
   const registerToGame = jest.fn();
-  const cancelRegisterGame = jest.fn();
+  const cancelRegisterToGame = jest.fn();
+  const cancelParticipateToGame = jest.fn();
 
   const renderPostsRegisterButton = ({
     gameId,
-    isRegistered,
-    registerErrorCodeAndMessage,
+    registerId,
+    registerStatus,
   }) => {
     render((
       <PostsRegisterButton
         gameId={gameId}
-        isRegistered={isRegistered}
+        registerId={registerId}
+        registerStatus={registerStatus}
         registerToGame={registerToGame}
-        cancelRegisterGame={cancelRegisterGame}
-        registerErrorCodeAndMessage={registerErrorCodeAndMessage}
+        cancelRegisterToGame={cancelRegisterToGame}
+        cancelParticipateToGame={cancelParticipateToGame}
       />
     ));
   };
 
   context('신청 버튼이 있으면 신청 버튼 클릭 시', () => {
     const gameId = 2;
-    const isRegistered = false;
-    const registerErrorCodeAndMessage = {};
+    const registerId = -1;
+    const registerStatus = 'none';
 
     it('운동 참가 신청 이벤트 핸들러 호출', () => {
       jest.clearAllMocks();
       renderPostsRegisterButton({
         gameId,
-        isRegistered,
-        registerErrorCodeAndMessage,
+        registerId,
+        registerStatus,
       });
 
       fireEvent.click(screen.getByText('신청'));
-      const expectedGameId = 2;
-      expect(registerToGame).toBeCalledWith(expectedGameId);
+      expect(registerToGame).toBeCalledWith(gameId);
     });
   });
 
   context('신청 취소 버튼이 있으면 신청 취소 버튼 클릭 시', () => {
-    const gameId = 1;
-    const isRegistered = true;
-    const registerErrorCodeAndMessage = {};
+    const gameId = 2;
+    const registerId = 7;
+    const registerStatus = 'processing';
 
     it('운동 참가 취소 이벤트 핸들러 호출', () => {
       jest.clearAllMocks();
       renderPostsRegisterButton({
         gameId,
-        isRegistered,
-        registerErrorCodeAndMessage,
+        registerId,
+        registerStatus,
       });
 
       fireEvent.click(screen.getByText('신청취소'));
-      const expectedGameId = 1;
-      expect(cancelRegisterGame).toBeCalledWith(expectedGameId);
+      expect(cancelRegisterToGame).toBeCalledWith(registerId);
     });
   });
 
-  context('신청 후 에러가 발생해 에러 상태가 전달되었을 시', () => {
-    const gameId = 10;
-    const isRegistered = false;
-    const registerErrorCodeAndMessage = {
-      code: 101,
-      message: '이미 신청이 완료된 운동입니다.',
-    };
+  context('참가 취소 버튼이 있으면 참가 취소 버튼 클릭 시', () => {
+    const gameId = 2;
+    const registerId = 7;
+    const registerStatus = 'accepted';
 
     it('에러 메세지 출력', () => {
       renderPostsRegisterButton({
         gameId,
-        isRegistered,
-        registerErrorCodeAndMessage,
+        registerId,
+        registerStatus,
       });
 
-      screen.getByText('이미 신청이 완료된 운동입니다.');
+      fireEvent.click(screen.getByText('참가취소'));
+      expect(cancelParticipateToGame).toBeCalledWith(registerId);
     });
   });
 });

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -23,8 +23,14 @@ export default function PostPage() {
   const fetchData = async () => {
     await postStore.fetchPost(postId);
     const gameId = await gameStore.fetchGame(postId);
-    if (gameId) {
+    const { isAuthor } = postStore.post;
+    if (gameId && !isAuthor) {
       await registerStore.fetchMembers(gameId);
+    }
+    if (gameId && isAuthor) {
+      console.log('접속자는 작성자이다.');
+      await registerStore.fetchMembers(gameId);
+      await registerStore.fetchApplicants(gameId);
     }
   };
 
@@ -34,10 +40,37 @@ export default function PostPage() {
 
   const { post } = postStore;
   const { game } = gameStore;
-  const { members } = registerStore;
+  const { members, applicants } = registerStore;
 
   const navigateToBackward = () => {
     navigate(-1);
+  };
+
+  const handleClickRegister = async (gameId) => {
+    const applicationId = await registerStore.registerToGame(gameId);
+    if (applicationId) {
+      await fetchData(postId);
+    }
+  };
+
+  const handleClickRegisterCancel = async (registerId) => {
+    await registerStore.cancelRegisterToGame(registerId);
+    await fetchData(postId);
+  };
+
+  const handleClickParticipateCancel = async (registerId) => {
+    await registerStore.cancelParticipateToGame(registerId);
+    await fetchData(postId);
+  };
+
+  const acceptRegister = async (registerId) => {
+    await registerStore.acceptRegister(registerId);
+    await fetchData(postId);
+  };
+
+  const rejectRegister = async (registerId) => {
+    await registerStore.rejectRegister(registerId);
+    await fetchData(postId);
   };
 
   return (
@@ -46,6 +79,12 @@ export default function PostPage() {
       post={post}
       game={game}
       members={members}
+      applicants={applicants}
+      handleClickRegister={handleClickRegister}
+      handleClickRegisterCancel={handleClickRegisterCancel}
+      handleClickParticipateCancel={handleClickParticipateCancel}
+      acceptRegister={acceptRegister}
+      rejectRegister={rejectRegister}
     />
   );
 }

--- a/src/pages/PostPage.test.jsx
+++ b/src/pages/PostPage.test.jsx
@@ -1,5 +1,5 @@
 import {
-  render, waitFor,
+  fireEvent, render, screen,
 } from '@testing-library/react';
 import context from 'jest-plugin-context';
 import PostPage from './PostPage';
@@ -32,10 +32,24 @@ jest.mock('../hooks/useGameStore', () => () => ({
 }));
 
 let members;
+let applicants;
 const fetchMembers = jest.fn();
+const fetchApplicants = jest.fn();
+let registerToGame;
+const cancelRegisterToGame = jest.fn();
+const cancelParticipateToGame = jest.fn();
+const acceptRegister = jest.fn();
+const rejectRegister = jest.fn();
 jest.mock('../hooks/useRegisterStore', () => () => ({
   members,
+  applicants,
   fetchMembers,
+  fetchApplicants,
+  registerToGame,
+  cancelRegisterToGame,
+  cancelParticipateToGame,
+  acceptRegister,
+  rejectRegister,
 }));
 
 describe('PostPage', () => {
@@ -45,55 +59,312 @@ describe('PostPage', () => {
     ));
   }
 
-  context('운동 모집 게시글 상세 정보 페이지에 접속하면', () => {
-    postId = 1;
+  context('게시글 작성자가 아닌 경우', () => {
+    context('운동 모집 게시글 상세 정보 페이지에 접속하면', () => {
+      beforeEach(() => {
+        postId = 1;
 
-    post = {
-      id: 1,
-      hits: 15,
-      authorName: '작성자명',
-      authorPhoneNumber: '010-6877-2291',
-      detail: '게시글 상세 정보 내용입니다.',
-      isAuthor: false,
-    };
-    game = {
-      id: 1,
-      type: '농구',
-      date: '2022년 12월 23일 20:00~22:00',
-      place: '인천삼산체육관',
-      currentMemberCount: 2,
-      targetMemberCount: 12,
-      isRegistered: true,
-    };
-    members = [
-      {
+        post = {
+          id: 1,
+          hits: 15,
+          authorName: '작성자',
+          authorPhoneNumber: '010-6877-2291',
+          detail: '게시글 상세 정보 내용입니다.',
+          isAuthor: false,
+        };
+        game = {
+          id: 1,
+          type: '농구',
+          date: '2022년 12월 23일 20:00~22:00',
+          place: '인천삼산체육관',
+          currentMemberCount: 2,
+          targetMemberCount: 12,
+          registerId: -1,
+          registerStatus: 'none',
+        };
+        members = [
+          {
+            id: 1,
+            name: '작성자',
+            gender: '남성',
+            phoneNumber: '010-6877-2291',
+          },
+        ];
+      });
+
+      it('운동 모집 게시글 상세 정보 상태들을 PostStore, '
+        + 'GameStore, MemberStore에서 순차적으로 fetch', async () => {
+        jest.clearAllMocks();
+        const expectedPostId = 1;
+        const expectedGameId = 1;
+        fetchGame = jest.fn(() => expectedGameId);
+
+        renderPostPage();
+
+        await expect(fetchPost).toBeCalledWith(expectedPostId);
+        await expect(fetchGame).toBeCalledWith(expectedPostId);
+        await expect(fetchMembers).toBeCalledWith(expectedGameId);
+        await expect(fetchApplicants).not.toBeCalled();
+      });
+    });
+
+    context('게시글에 참가 신청 버튼이 출력되는 상태에서 사용자가 참가 신청 버튼을 누르면', () => {
+      beforeEach(() => {
+        postId = 1;
+
+        post = {
+          id: 1,
+          hits: 15,
+          authorName: '작성자',
+          authorPhoneNumber: '010-6877-2291',
+          detail: '게시글 상세 정보 내용입니다.',
+          isAuthor: false,
+        };
+        game = {
+          id: 1,
+          type: '야구',
+          date: '2022년 09월 30일 14:00~17:00',
+          place: '한화생명이글스파크',
+          currentMemberCount: 1,
+          targetMemberCount: 6,
+          registerId: -1,
+          registerStatus: 'none',
+        };
+        members = [
+          {
+            id: 1,
+            name: '작성자',
+            gender: '남성',
+            phoneNumber: '010-6877-2291',
+          },
+        ];
+      });
+
+      it('해당 게임에 참가를 신청하는 운동 참가 신청 함수 호출 후, '
+        + '신청 번호를 성공적으로 반환했을 경우 게시글 상세 정보를 순차적으로 fetch', async () => {
+        jest.clearAllMocks();
+        const expectedPostId = 1;
+        const expectedGameId = 1;
+        const expectedApplicationId = 2;
+        registerToGame = jest.fn(() => expectedApplicationId);
+        fetchGame = jest.fn(() => expectedGameId);
+
+        renderPostPage();
+
+        fireEvent.click(screen.getByText('신청'));
+        await expect(registerToGame).toBeCalledWith(expectedGameId);
+        await expect(fetchPost).nthCalledWith(2, expectedPostId);
+        await expect(fetchGame).nthCalledWith(2, expectedPostId);
+        await expect(fetchMembers).nthCalledWith(2, expectedGameId);
+        await expect(fetchApplicants).not.toBeCalled();
+      });
+    });
+
+    context('게시글에 참가 신청 취소 버튼이 출력되는 상태에서 사용자가 참가 신청 취소 버튼을 누르면', () => {
+      beforeEach(() => {
+        postId = 1;
+
+        post = {
+          id: 1,
+          hits: 15,
+          authorName: '작성자',
+          authorPhoneNumber: '010-6877-2291',
+          detail: '게시글 상세 정보 내용입니다.',
+          isAuthor: false,
+        };
+        game = {
+          id: 2,
+          type: '수영',
+          date: '2022년 12월 26일 07:00~09:00',
+          place: '박태환수영장',
+          currentMemberCount: 2,
+          targetMemberCount: 6,
+          registerId: 17,
+          registerStatus: 'processing',
+        };
+        members = [
+          {
+            id: 1,
+            name: '작성자',
+            gender: '남성',
+            phoneNumber: '010-6877-2291',
+          },
+          {
+            id: 17,
+            name: '수영 좋아하는 사람',
+            gender: '남성',
+            phoneNumber: '010-5555-5555',
+          },
+        ];
+      });
+
+      it('해당 신청의 상태를 변경하는 운동 참가 신청 취소 함수 호출 후, '
+      + '게시글 상세 정보를 순차적으로 fetch', async () => {
+        jest.clearAllMocks();
+        const expectedPostId = 1;
+        const expectedGameId = 2;
+        const expectedRegisterId = 17;
+        fetchGame = jest.fn(() => expectedGameId);
+
+        renderPostPage();
+
+        fireEvent.click(screen.getByText('신청취소'));
+        await expect(cancelRegisterToGame).toBeCalledWith(expectedRegisterId);
+        await expect(fetchPost).nthCalledWith(2, expectedPostId);
+        await expect(fetchGame).nthCalledWith(2, expectedPostId);
+        await expect(fetchMembers).nthCalledWith(2, expectedGameId);
+        await expect(fetchApplicants).not.toBeCalled();
+      });
+    });
+
+    context('게시글에 참가 취소 버튼이 출력되는 상태에서 사용자가 참가 취소 버튼을 누르면', () => {
+      beforeEach(() => {
+        postId = 1;
+
+        post = {
+          id: 1,
+          hits: 15,
+          authorName: '작성자',
+          authorPhoneNumber: '010-6877-2291',
+          detail: '게시글 상세 정보 내용입니다.',
+          isAuthor: false,
+        };
+        game = {
+          id: 2,
+          type: '양궁',
+          date: '2022년 1월 30일 17:00~19:00',
+          place: '진천국가대표선수촌훈련장 양궁장',
+          currentMemberCount: 2,
+          targetMemberCount: 2,
+          registerId: 20,
+          registerStatus: 'accepted',
+        };
+        members = [
+          {
+            id: 1,
+            name: '작성자',
+            gender: '남성',
+            phoneNumber: '010-6877-2291',
+          },
+          {
+            id: 20,
+            name: '안산',
+            gender: '여성',
+            phoneNumber: '010-8765-4321',
+          },
+        ];
+      });
+
+      it('해당 신청의 상태를 변경하는 운동 참가 취소 함수 호출 후, '
+      + '게시글 상세 정보를 순차적으로 fetch', async () => {
+        jest.clearAllMocks();
+        const expectedPostId = 1;
+        const expectedGameId = 2;
+        const expectedRegisterId = 20;
+        fetchGame = jest.fn(() => expectedGameId);
+
+        renderPostPage();
+
+        fireEvent.click(screen.getByText('참가취소'));
+        await expect(cancelParticipateToGame).toBeCalledWith(expectedRegisterId);
+        await expect(fetchPost).nthCalledWith(2, expectedPostId);
+        await expect(fetchGame).nthCalledWith(2, expectedPostId);
+        await expect(fetchMembers).nthCalledWith(2, expectedGameId);
+        await expect(fetchApplicants).not.toBeCalled();
+      });
+    });
+  });
+
+  context('게시글 작성자인 경우', () => {
+    beforeEach(() => {
+      postId = 1;
+
+      post = {
         id: 1,
-        name: '사용자 1',
-        gender: '남성',
-        phoneNumber: '010-1234-5678',
-      },
-      {
+        hits: 15,
+        authorName: '작성자',
+        authorPhoneNumber: '010-6877-2291',
+        detail: '게시글 상세 정보 내용입니다.',
+        isAuthor: true,
+      };
+      game = {
         id: 2,
-        name: '사용자 2',
-        gender: '남성',
-        phoneNumber: '010-8765-4321',
-      },
-    ];
+        type: '육상',
+        date: '2022년 5월 14일 20:00~21:00',
+        place: '잠실종합운동장',
+        currentMemberCount: 1,
+        targetMemberCount: 5,
+        registerId: 4,
+        registerStatus: 'accepted',
+      };
+      members = [
+        {
+          id: 1,
+          name: '작성자',
+          gender: '남성',
+          phoneNumber: '010-6877-2291',
+        },
+      ];
+      applicants = [
+        {
+          id: 3,
+          name: '이봉주',
+          gender: '남성',
+          phoneNumber: '010-2424-2424',
+        },
+      ];
+    });
 
-    it('운동 모집 게시글 상세 정보 상태들을 PostStore, '
-      + 'GameStore, MemberStore에서 순차적으로 fetch', async () => {
+    it('운동 모집 게시글 상세 정보 및 신청자 정보 상태들을 PostStore, '
+    + 'GameStore, MemberStore에서 순차적으로 fetch', async () => {
       jest.clearAllMocks();
       const expectedPostId = 1;
-      const expectedGameId = 1;
+      const expectedGameId = 2;
       fetchGame = jest.fn(() => expectedGameId);
 
       renderPostPage();
 
-      await waitFor(() => {
-        expect(fetchPost).toBeCalledWith(expectedPostId);
-        expect(fetchGame).toBeCalledWith(expectedPostId);
-        expect(fetchGame).toReturnWith(expectedGameId);
-        expect(fetchMembers).toBeCalledWith(expectedGameId);
+      await expect(fetchPost).toBeCalledWith(expectedPostId);
+      await expect(fetchGame).toBeCalledWith(expectedPostId);
+      await expect(fetchMembers).toBeCalledWith(expectedGameId);
+      await expect(fetchApplicants).toBeCalledWith(expectedGameId);
+    });
+
+    context('신청자에 대해 수락 버튼을 눌렀을 경우', () => {
+      it('참가 신청 수락 함수 호출 후, 게시글 상세 정보를 순차적으로 fetch', async () => {
+        jest.clearAllMocks();
+        const expectedPostId = 1;
+        const expectedGameId = 2;
+        const expectedRegisterId = 3;
+        fetchGame = jest.fn(() => expectedGameId);
+
+        renderPostPage();
+
+        fireEvent.click(screen.getByText('수락'));
+        await expect(acceptRegister).toBeCalledWith(expectedRegisterId);
+        await expect(fetchPost).nthCalledWith(2, expectedPostId);
+        await expect(fetchGame).nthCalledWith(2, expectedPostId);
+        await expect(fetchMembers).nthCalledWith(2, expectedGameId);
+        await expect(fetchApplicants).nthCalledWith(2, expectedGameId);
+      });
+    });
+
+    context('신청자에 대해 거절 버튼을 눌렀을 경우', () => {
+      it('참가 신청 거절 함수 호출 후, 게시글 상세 정보를 순차적으로 fetch', async () => {
+        jest.clearAllMocks();
+        const expectedPostId = 1;
+        const expectedGameId = 2;
+        const expectedRegisterId = 3;
+        fetchGame = jest.fn(() => expectedGameId);
+
+        renderPostPage();
+
+        fireEvent.click(screen.getByText('거절'));
+        await expect(rejectRegister).toBeCalledWith(expectedRegisterId);
+        await expect(fetchPost).nthCalledWith(2, expectedPostId);
+        await expect(fetchGame).nthCalledWith(2, expectedPostId);
+        await expect(fetchMembers).nthCalledWith(2, expectedGameId);
+        await expect(fetchApplicants).nthCalledWith(2, expectedGameId);
       });
     });
   });

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -35,14 +35,19 @@ export default function PostsPage() {
   };
 
   const registerToGame = async (gameId) => {
-    const registeredGameId = await registerStore.registerToGame(gameId);
-    if (registeredGameId) {
+    const applicationId = await registerStore.registerToGame(gameId);
+    if (applicationId) {
       await postStore.fetchPosts();
     }
   };
 
-  const cancelRegisterGame = async (gameId) => {
-    await registerStore.cancelParticipateGame(gameId);
+  const cancelRegisterToGame = async (registerId) => {
+    await registerStore.cancelRegisterToGame(registerId);
+    await postStore.fetchPosts();
+  };
+
+  const cancelParticipateToGame = async (registerId) => {
+    await registerStore.cancelParticipateToGame(registerId);
     await postStore.fetchPosts();
   };
 
@@ -51,12 +56,13 @@ export default function PostsPage() {
   return (
     <Posts
       posts={posts}
-      navigateToPost={navigateToPost}
       navigateToBackward={navigateToBackward}
+      navigateToPost={navigateToPost}
+      registerToGame={registerToGame}
+      cancelRegisterToGame={cancelRegisterToGame}
+      cancelParticipateToGame={cancelParticipateToGame}
       postsErrorMessage={postsErrorMessage}
       registerErrorCodeAndMessage={registerErrorCodeAndMessage}
-      registerToGame={registerToGame}
-      cancelRegisterGame={cancelRegisterGame}
     />
   );
 }

--- a/src/services/RegisterApiService.js
+++ b/src/services/RegisterApiService.js
@@ -21,6 +21,12 @@ export default class RegisterApiService {
     return data;
   }
 
+  async fetchApplicants(gameId) {
+    const url = `${apiBaseUrl}/registers/applicants/games/${gameId}`;
+    const { data } = await axios.get(url);
+    return data;
+  }
+
   async registerToGame(gameId) {
     const url = `${apiBaseUrl}/registers/games/${gameId}`;
     const { data } = await axios.post(url, {}, {
@@ -31,9 +37,40 @@ export default class RegisterApiService {
     return data.gameId;
   }
 
-  async cancelParticipateGame(gameId) {
-    const url = `${apiBaseUrl}/registers/games/${gameId}`;
+  async cancelRegisterToGame(registerId) {
+    const url = `${apiBaseUrl}/registers/${registerId}`;
     await axios.patch(url, { }, {
+      params: { status: 'canceled' },
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
+  }
+
+  async cancelParticipateToGame(registerId) {
+    const url = `${apiBaseUrl}/registers/${registerId}`;
+    await axios.patch(url, { }, {
+      params: { status: 'canceled' },
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
+  }
+
+  async acceptRegister(registerId) {
+    const url = `${apiBaseUrl}/registers/${registerId}`;
+    await axios.patch(url, { }, {
+      params: { status: 'accepted' },
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
+  }
+
+  async rejectRegister(registerId) {
+    const url = `${apiBaseUrl}/registers/${registerId}`;
+    await axios.patch(url, { }, {
+      params: { status: 'rejected' },
       headers: {
         Authorization: `Bearer ${this.accessToken}`,
       },

--- a/src/stores/GameStore.test.js
+++ b/src/stores/GameStore.test.js
@@ -15,8 +15,9 @@ describe('GameStore', () => {
 
       const { game, gameErrorMessage } = gameStore;
 
-      expect(Object.keys(game).length).toBe(7);
+      expect(Object.keys(game).length).toBe(8);
       expect(game.place).toBe('서울숲탁구클럽');
+      expect(game.registerStatus).toBe('none');
       expect(gameErrorMessage).toBeFalsy();
     });
   });

--- a/src/stores/PostStore.test.js
+++ b/src/stores/PostStore.test.js
@@ -19,9 +19,10 @@ describe('PostStore', () => {
 
       expect(posts.length).toBe(2);
       expect(posts[0].hits).toBe(334);
-      expect(posts[0].game.isRegistered).toBe(false);
+      expect(posts[0].isAuthor).toBe(false);
+      expect(posts[0].game.registerId).toBe(-1);
       expect(posts[1].game.targetMemberCount).toBe(12);
-      expect(posts[1].game.isRegistered).toBe(true);
+      expect(posts[1].game.registerStatus).toBe('accepted');
       expect(postsErrorMessage).toBeFalsy();
     });
   });

--- a/src/stores/RegisterStore.js
+++ b/src/stores/RegisterStore.js
@@ -12,6 +12,9 @@ export default class RegisterStore extends Store {
 
     this.members = [];
     this.membersErrorMessage = '';
+
+    this.applicants = [];
+    this.applicantsErrorMessage = '';
   }
 
   async fetchMembers(gameId) {
@@ -22,6 +25,21 @@ export default class RegisterStore extends Store {
     } catch (error) {
       const { errorMessage } = error.response.data;
       this.membersErrorMessage = errorMessage;
+      this.publish();
+    }
+  }
+
+  async fetchApplicants(gameId) {
+    try {
+      const data = await registerApiService.fetchApplicants(gameId);
+      this.applicants = data.applicants;
+      console.log(data);
+      console.log('RegisterStore After fetchApplicants');
+      console.log(this.applicants);
+      this.publish();
+    } catch (error) {
+      const { errorMessage } = error.response.data;
+      this.applicantsErrorMessage = errorMessage;
       this.publish();
     }
   }
@@ -40,8 +58,20 @@ export default class RegisterStore extends Store {
     }
   }
 
-  async cancelParticipateGame(gameId) {
-    await registerApiService.cancelParticipateGame(gameId);
+  async cancelRegisterToGame(registerId) {
+    await registerApiService.cancelRegisterToGame(registerId);
+  }
+
+  async cancelParticipateToGame(registerId) {
+    await registerApiService.cancelParticipateToGame(registerId);
+  }
+
+  async acceptRegister(registerId) {
+    await registerApiService.acceptRegister(registerId);
+  }
+
+  async rejectRegister(registerId) {
+    await registerApiService.rejectRegister(registerId);
   }
 }
 

--- a/src/stores/RegisterStore.test.js
+++ b/src/stores/RegisterStore.test.js
@@ -26,8 +26,24 @@ describe('RegisterStore', () => {
     });
   });
 
+  context('API 서버에 게시글 게임의 신청자 상세 정보 데이터를 요청할 경우', () => {
+    const gameId = 2;
+
+    it('백엔드 서버에서 응답으로 전달된 applicant 컬렉션을 상태로 저장', async () => {
+      registerApiService.setAccessToken('userId 1');
+      await registerStore.fetchApplicants(gameId);
+
+      const { applicants, applicantsErrorMessage } = registerStore;
+
+      expect(applicants.length).toBe(2);
+      expect(applicants[0].name).toBe('신청자 1');
+      expect(applicants[1].gender).toBe('남성');
+      expect(applicantsErrorMessage).toBeFalsy();
+    });
+  });
+
   context('운동 참가 신청 API를 요청할 경우 (정상 케이스)', () => {
-    it('registerApiService API 요청을 호출하고 응답으로 받은 gameId를 반환', async () => {
+    it('registerApiService 신청자 생성 POST API 요청을 호출하고 응답으로 받은 gameId를 반환', async () => {
       // cf. localStorage.setItem()으로 token을 설정해줄 수도 있다.
       registerApiService.setAccessToken('userId 1');
       const gameId = 1;
@@ -88,11 +104,35 @@ describe('RegisterStore', () => {
     });
   });
 
-  context('운동 참가 취소 API를 요청할 경우', () => {
-    it('memberApiService API 요청을 호출', async () => {
+  context('운동 참가 신청 취소 API를 요청할 경우', () => {
+    it('RegisterApiService 신청자 상태를 취소로 변경하는 PATCH API 요청 호출', async () => {
       registerApiService.setAccessToken('userId 1');
-      const gameId = 1;
-      await registerStore.cancelParticipateGame(gameId);
+      const registerId = 1;
+      await registerStore.cancelRegisterToGame(registerId);
+    });
+  });
+
+  context('운동 참가 취소 API를 요청할 경우', () => {
+    it('RegisterApiService 신청자 상태를 취소로 변경하는 PATCH API 요청 호출', async () => {
+      registerApiService.setAccessToken('userId 1');
+      const registerId = 1;
+      await registerStore.cancelParticipateToGame(registerId);
+    });
+  });
+
+  context('운동 참가 수락 API를 요청할 경우', () => {
+    it('RegisterApiService 신청자 상태를 참가로 변경하는 PATCH API 요청 호출', async () => {
+      registerApiService.setAccessToken('userId 1');
+      const registerId = 1;
+      await registerStore.acceptRegister(registerId);
+    });
+  });
+
+  context('운동 참가 거절 API를 요청할 경우', () => {
+    it('RegisterApiService 신청자 상태를 거절로 변경하는 PATCH API 요청 호출', async () => {
+      registerApiService.setAccessToken('userId 1');
+      const registerId = 1;
+      await registerStore.rejectRegister(registerId);
     });
   });
 });

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -21,25 +21,29 @@ const postTestServer = setupServer(
             {
               id: 1,
               hits: 334,
+              isAuthor: false,
               game: {
                 type: '축구',
                 date: '2022년 10월 19일 13:00~16:00',
                 place: '대전월드컵경기장',
                 currentMemberCount: 16,
                 targetMemberCount: 22,
-                isRegistered: false,
+                registerId: -1,
+                registerStatus: 'none',
               },
             },
             {
               id: 2,
               hits: 10,
+              isAuthor: false,
               game: {
                 type: '농구',
                 date: '2022년 10월 20일 15:00~17:00',
                 place: '잠실실내체육관',
                 currentMemberCount: 2,
                 targetMemberCount: 12,
-                isRegistered: true,
+                registerId: 10,
+                registerStatus: 'accepted',
               },
             },
           ],
@@ -210,7 +214,8 @@ const postTestServer = setupServer(
             place: '서울숲탁구클럽',
             currentMemberCount: 2,
             targetMemberCount: 4,
-            isRegistered: true,
+            registerId: -1,
+            registerStatus: 'none',
           }),
         );
       }
@@ -246,6 +251,60 @@ const postTestServer = setupServer(
               },
             ],
           }),
+        );
+      }
+
+      return response(
+        context.status(400),
+      );
+    },
+  ),
+
+  // fetchApplicants
+  rest.get(
+    `${apiBaseUrl}/registers/applicants/games/:gameId`,
+    async (request, response, context) => {
+      const { gameId } = await request.params;
+
+      if (gameId === '2') {
+        return response(
+          context.status(200),
+          context.json({
+            applicants: [
+              {
+                id: 1,
+                name: '신청자 1',
+                gender: '여성',
+                phoneNumber: '010-1357-1357',
+              },
+              {
+                id: 2,
+                name: '신청자 2',
+                gender: '남성',
+                phoneNumber: '010-2468-2468',
+              },
+            ],
+          }),
+        );
+      }
+
+      return response(
+        context.status(400),
+      );
+    },
+  ),
+
+  // change register state methods
+  rest.patch(
+    `${apiBaseUrl}/registers/:registerId`,
+    async (request, response, context) => {
+      const status = await request.url.searchParams.get('status');
+
+      if (status === 'canceled'
+        || status === 'accepted'
+        || status === 'rejected') {
+        return response(
+          context.status(204),
         );
       }
 


### PR DESCRIPTION
목표 동작

미신청자
- 게시글의 경기 미신청자는 자신이 참가하지 않는 게시글을 확인할 경우 신청 버튼을 확인할 수 있음
- none (canceled, rejected인 경우에도 none으로 받아오게 함)

신청자
- 게시글의 경기 신청자는 자신이 참가 신청을 누른 게시글을 확인할 경우 신청취소 버튼을 확인할 수 있음
- processing

참가자
- 게시글의 경기 참가자는 자신이 참가하는 게시글을 확인할 경우 참가자 목록에서 자신의 정보와 참가취소 버튼을 확인할 수 있음
- accepted

작성자
- 게시글의 작성자는 자신이 작성한 게시글을 확인할 경우 신청/신청취소/참가취소 버튼은 나타나지 않음
- 대신 참가자 목록과 신청자 목록을 확인할 수 있음
- 신청자 목록에는 각 신청자별로 수락/거절 버튼이 출력되는 것을 확인할 수 있음

진행
각 버튼 클릭 시 RegisterStore의 관련 메서드를 호출해 RegisterApiService의 REST API를 호출하는 영역까지 구현

예상 뽀모 3
실제 뽀모 6

이슈
UI 구분 작업은 게시글 상세내용 조회뿐만 아니라 게시글 목록 조회 시에도 필요했기 때문에
게시글 목록 조회 작업과 같이 진행했음 (작업량 2배)
네이밍을 중간중간 계속 변경하는 과정에서 시간이 추가되었음 (약 1~2뽀모)
별도의 작업으로 분리되어 있던 API 호출 및 DTO 구조 수정까지 같이 수행했음 (3뽀모)