### PR TITLE
로그인 기능 리팩터링, 로그인을 별도의 페이지에서 수행

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "axios": "^1.1.3",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-hook-form": "^7.39.5",
                 "react-router-dom": "^6.4.2",
                 "styled-components": "^5.3.6",
                 "styled-reset": "^4.4.2",
@@ -12814,6 +12815,21 @@
             "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
             "dev": true
         },
+        "node_modules/react-hook-form": {
+            "version": "7.39.5",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.39.5.tgz",
+            "integrity": "sha512-OE0HKyz5IPc6svN2wd+e+evidZrw4O4WZWAWYzQVZuHi+hYnHFSLnxOq0ddjbdmaLIsLHut/ab7j72y2QT3+KA==",
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/react-hook-form"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17 || ^18"
+            }
+        },
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -24596,6 +24612,12 @@
             "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
             "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
             "dev": true
+        },
+        "react-hook-form": {
+            "version": "7.39.5",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.39.5.tgz",
+            "integrity": "sha512-OE0HKyz5IPc6svN2wd+e+evidZrw4O4WZWAWYzQVZuHi+hYnHFSLnxOq0ddjbdmaLIsLHut/ab7j72y2QT3+KA==",
+            "requires": {}
         },
         "react-is": {
             "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "axios": "^1.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.39.5",
         "react-router-dom": "^6.4.2",
         "styled-components": "^5.3.6",
         "styled-reset": "^4.4.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,10 +15,9 @@ import PostsPage from './pages/PostsPage';
 import PostListMapPage from './pages/PostListMapPage';
 import PostPage from './pages/PostPage';
 import WritePage from './pages/WritePage';
-import CreateClubPage from './pages/CreateClubPage';
-import ClubsPage from './pages/ClubsPage';
 import BottomNavigator from './components/BottomNavigator';
 import GlobalStyle from './styles/GlobalStyle';
+import LoginPage from './pages/LoginPage';
 
 const Container = styled.div`
   height: 100vh;
@@ -53,11 +52,10 @@ export default function App() {
             <Route path="/" element={<HomePage />} />
             <Route path="/posts/list" element={<PostsPage />} />
             <Route path="/posts/:postId" element={<PostPage />} />
+            <Route path="/login" element={<LoginPage />} />
 
-            <Route path="/posts/map" element={<PostListMapPage />} />
             <Route path="/write" element={<WritePage />} />
-            <Route path="/clubs" element={<ClubsPage />} />
-            <Route path="/clubs/create" element={<CreateClubPage />} />
+            <Route path="/posts/map" element={<PostListMapPage />} />
           </Routes>
         </Wrapper>
       </Container>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useLocalStorage } from 'usehooks-ts';
-import useUserStore from '../hooks/useUserStore';
 
 const Container = styled.header`
   position: fixed;
@@ -33,27 +32,13 @@ export default function Header() {
 
   const [accessToken, setAccessToken] = useLocalStorage('accessToken', '');
 
-  const userStore = useUserStore();
-
-  const { userId } = userStore;
-
-  const handleChangeUserId = (event) => {
-    const value = Number(event.target.value);
-    userStore.changeUserId(value);
-  };
-
-  const handleSubmit = async (event) => {
-    event.preventDefault();
-    const verifiedAccessToken = await userStore.login();
-    if (verifiedAccessToken) {
-      setAccessToken(verifiedAccessToken);
-      userStore.changeUserId('');
-    }
-  };
-
   const handleClickLogout = () => {
     setAccessToken('');
     navigate('/');
+  };
+
+  const navigateToLoginPage = () => {
+    navigate('/login');
   };
 
   return (
@@ -68,19 +53,12 @@ export default function Header() {
             로그아웃
           </button>
         ) : (
-          <form onSubmit={handleSubmit}>
-            <label htmlFor="userId">User Id:</label>
-            <input
-              id="userId"
-              value={userId}
-              onChange={(event) => handleChangeUserId(event)}
-            />
-            <button
-              type="submit"
-            >
-              로그인
-            </button>
-          </form>
+          <button
+            type="button"
+            onClick={navigateToLoginPage}
+          >
+            LOGIN
+          </button>
         )}
       </Side>
     </Container>

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -3,23 +3,20 @@ import {
 } from '@testing-library/react';
 
 import context from 'jest-plugin-context';
-import { MemoryRouter } from 'react-router-dom';
 
 import Header from './Header';
 
-const changeUserId = jest.fn();
-let login;
-jest.mock('../hooks/useUserStore', () => () => ({
-  changeUserId,
-  login,
+const navigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => (
+    navigate
+  ),
 }));
 
 describe('Header', () => {
   const renderHeader = () => {
     render((
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
+      <Header />
     ));
   };
 
@@ -31,41 +28,21 @@ describe('Header', () => {
     });
 
     context('로그인이 되어있지 않은 경우', () => {
-      it('User 식별자 입력란, 로그인 버튼 출력', () => {
+      it('로그인 페이지 이동 링크 버튼 출력', () => {
         localStorage.setItem('accessToken', '');
         renderHeader();
 
-        screen.getByLabelText('User Id:');
-        screen.getByText('로그인');
-      });
-
-      context('값을 입력할 경우', () => {
-        it('입력한 user Id 값을 변경하는 UserStore의 changeUserId 함수 호출', async () => {
-          localStorage.setItem('accessToken', '');
-          renderHeader();
-
-          // await act(() => {
-          fireEvent.change(screen.getByLabelText(/User Id/), {
-            target: { value: 2 },
-          });
-          expect(changeUserId).toBeCalledWith(2);
-          // });
-        });
+        screen.getByText('LOGIN');
       });
 
       context('로그인 버튼을 누를 경우', () => {
-        const expectedAccessToken = 'VALID ACCESS TOKEN';
-
-        it('accessToken을 받아오기 위한 UserStore의 login 함수 호출', async () => {
-          login = jest.fn(() => expectedAccessToken);
+        it('로그인 페이지로 이동하는 navigate 함수 호출', async () => {
           localStorage.setItem('accessToken', '');
           renderHeader();
 
-          // await act(() => {
-          fireEvent.click(screen.getByText('로그인'));
+          fireEvent.click(screen.getByText('LOGIN'));
 
-          expect(login).toBeCalled();
-          // });
+          expect(navigate).toBeCalledWith('/login');
         });
       });
     });
@@ -83,11 +60,9 @@ describe('Header', () => {
           localStorage.setItem('accessToken', JSON.stringify('TOKEN'));
           renderHeader();
 
-          // await act(() => {
           fireEvent.click(screen.getByText('로그아웃'));
           const accessToken = localStorage.getItem('accessToken');
           expect(JSON.parse(accessToken)).toBe('');
-          // });
         });
       });
     });

--- a/src/components/LoginErrors.jsx
+++ b/src/components/LoginErrors.jsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const Error = styled.p`
+  font-size: 1.3em;
+  text-align: center;
+`;
+
+export default function LoginErrors({
+  loginFormError,
+  loginProcessError,
+}) {
+  if (!Object.keys(loginFormError).length && !loginProcessError) {
+    return (
+      null
+    );
+  }
+
+  if (Object.keys(loginFormError).length >= 1) {
+    return (
+      <div>
+        {loginFormError.identifier ? (
+          <Error>{loginFormError.identifier.message}</Error>
+        ) : (
+          <Error>{loginFormError.password.message}</Error>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Error>{loginProcessError}</Error>
+  );
+}

--- a/src/components/LoginErrors.test.jsx
+++ b/src/components/LoginErrors.test.jsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import LoginErrors from './LoginErrors';
+
+describe('LoginErrors', () => {
+  const renderLoginErrors = (
+    loginFormError,
+    loginProcessError,
+  ) => {
+    render((
+      <LoginErrors
+        loginFormError={loginFormError}
+        loginProcessError={loginProcessError}
+      />
+    ));
+  };
+
+  context('로그인 폼 에러 메세지가 전달되면', () => {
+    context('아이디를 입력하지 않았을 경우', () => {
+      const loginFormError = {
+        identifier: {
+          message: '아이디를 입력해주세요.',
+        },
+      };
+      const loginProcessError = '';
+
+      it('아이디가 없다는 예외 메시지 출력', () => {
+        renderLoginErrors(
+          loginFormError,
+          loginProcessError,
+        );
+
+        screen.getByText('아이디를 입력해주세요.');
+        expect(screen.queryByText('비밀번호를 입력해주세요.')).toBe(null);
+      });
+    });
+
+    context('비밀번호를 입력하지 않았을 경우', () => {
+      const loginFormError = {
+        password: {
+          message: '비밀번호를 입력해주세요.',
+        },
+      };
+      const loginProcessError = '';
+
+      it('비밀번호가 없다는 예외 메시지 출력', () => {
+        renderLoginErrors(
+          loginFormError,
+          loginProcessError,
+        );
+
+        screen.getByText('비밀번호를 입력해주세요.');
+        expect(screen.queryByText('아이디를 입력해주세요.')).toBe(null);
+      });
+    });
+  });
+
+  context('로그인 백엔드 에러 메세지가 전달되면', () => {
+    context('잘못된 아이디를 입력했을 경우', () => {
+      const loginFormError = {};
+      const loginProcessError = '존재하지 않는 아이디입니다.';
+
+      it('존재하지 않는 아이디라는 예외 메시지 출력', () => {
+        renderLoginErrors(
+          loginFormError,
+          loginProcessError,
+        );
+
+        screen.getByText('존재하지 않는 아이디입니다.');
+      });
+    });
+
+    context('잘못된 비밀번호를 입력했을 경우', () => {
+      const loginFormError = {};
+      const loginProcessError = '비밀번호가 일치하지 않습니다.';
+
+      it('비밀번호가 일치하지 않는다는 예외 메시지 출력', () => {
+        renderLoginErrors(
+          loginFormError,
+          loginProcessError,
+        );
+
+        screen.getByText('비밀번호가 일치하지 않습니다.');
+      });
+    });
+  });
+
+  context('로그인 폼, 백엔드 에러 메세지가 동시에 전달되면', () => {
+    const loginFormError = {
+      identifier: {
+        message: '아이디를 입력해주세요.',
+      },
+    };
+    const loginProcessError = '비밀번호가 일치하지 않습니다.';
+
+    it('로그인 폼 에러 메세지를 출력', () => {
+      renderLoginErrors(
+        loginFormError,
+        loginProcessError,
+      );
+
+      screen.getByText('아이디를 입력해주세요.');
+      expect(screen.queryByText('비밀번호가 일치하지 않습니다.')).toBe(null);
+    });
+  });
+});

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,0 +1,78 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+import styled from 'styled-components';
+
+const Container = styled.article`
+  padding-block: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const Form = styled.form`
+  display: grid;
+  grid-template-rows: 1fr 1fr 1fr;
+  gap: 1em;
+
+  label {
+    display: none;
+  }
+`;
+
+const Input = styled.input`
+  font-size: 1.3em;
+`;
+
+const Button = styled.button`
+  font-size: 1.3em;
+`;
+
+export default function LoginForm({
+  register,
+  handleSubmit,
+  login,
+}) {
+  const submit = async (data) => {
+    await login(data);
+  };
+
+  return (
+    <Container>
+      <Form onSubmit={handleSubmit(submit)}>
+        <div>
+          <label htmlFor="input-identifier">
+            아이디
+          </label>
+          <Input
+            id="input-identifier"
+            type="text"
+            placeholder="아이디"
+            {...register(
+              'identifier',
+              { required: { value: true, message: '아이디를 입력해주세요.' } },
+            )}
+          />
+        </div>
+        <div>
+          <label htmlFor="input-password">
+            비밀번호
+          </label>
+          <Input
+            id="input-password"
+            type="password"
+            placeholder="비밀번호"
+            {...register(
+              'password',
+              { required: { value: true, message: '비밀번호를 입력해주세요.' } },
+            )}
+          />
+        </div>
+        <Button
+          type="submit"
+        >
+          로그인
+        </Button>
+      </Form>
+    </Container>
+  );
+}

--- a/src/components/LoginForm.test.jsx
+++ b/src/components/LoginForm.test.jsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import LoginForm from './LoginForm';
+
+describe('LoginForm', () => {
+  const register = jest.fn();
+  const handleSubmit = jest.fn();
+  const login = jest.fn();
+
+  const renderLoginForm = () => {
+    render((
+      <LoginForm
+        register={register}
+        handleSubmit={handleSubmit}
+        login={login}
+      />
+    ));
+  };
+
+  context('로그인 폼이 나타나면', () => {
+    it('아이디와 비밀번호를 입력할 수 있는 란이 있음', () => {
+      renderLoginForm();
+
+      screen.getByLabelText('아이디');
+      screen.getByLabelText('비밀번호');
+      screen.getByText('로그인');
+    });
+
+    context('폼에 값을 입력하면', () => {
+      it('폼의 내용이 변경됨', () => {
+        renderLoginForm();
+
+        fireEvent.change(screen.getByLabelText('아이디'), {
+          target: { value: 'hsjkdss228' },
+        });
+        screen.getByDisplayValue('hsjkdss228');
+        fireEvent.change(screen.getByLabelText('비밀번호'), {
+          target: { value: 'Password!1' },
+        });
+        screen.getByDisplayValue('Password!1');
+      });
+    });
+  });
+});

--- a/src/pages/ClubsPage.jsx
+++ b/src/pages/ClubsPage.jsx
@@ -1,5 +1,0 @@
-export default function ClubsPage() {
-  return (
-    <p>클럽 목록 보기 페이지</p>
-  );
-}

--- a/src/pages/CreateClubPage.jsx
+++ b/src/pages/CreateClubPage.jsx
@@ -1,5 +1,0 @@
-export default function CreateClubPage() {
-  return (
-    <p>클럽 생성하기 페이지</p>
-  );
-}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Container = styled.article`
-  
+  padding-block: 30px;
 `;
 
 const Menus = styled.section`

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,43 @@
+import { useForm } from 'react-hook-form';
+import { useLocalStorage } from 'usehooks-ts';
+import { useNavigate } from 'react-router-dom';
+import useUserStore from '../hooks/useUserStore';
+import LoginForm from '../components/LoginForm';
+import LoginErrors from '../components/LoginErrors';
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+
+  const [, setAccessToken] = useLocalStorage('accessToken', '');
+
+  const userStore = useUserStore();
+
+  const { register, handleSubmit, formState: { errors } } = useForm({ reValidateMode: 'onSubmit' });
+
+  const login = async (data) => {
+    const { identifier, password } = data;
+    const verifiedAccessToken = await userStore.login({ identifier, password });
+    if (verifiedAccessToken) {
+      setAccessToken(verifiedAccessToken);
+      navigate('/');
+    }
+  };
+
+  const { loginErrorMessage } = userStore;
+
+  return (
+    <>
+      <LoginForm
+        register={register}
+        handleSubmit={handleSubmit}
+        login={login}
+        loginFormError={errors}
+        loginProcessError={loginErrorMessage}
+      />
+      <LoginErrors
+        loginFormError={errors}
+        loginProcessError={loginErrorMessage}
+      />
+    </>
+  );
+}

--- a/src/pages/LoginPage.test.jsx
+++ b/src/pages/LoginPage.test.jsx
@@ -1,0 +1,78 @@
+import {
+  fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import context from 'jest-plugin-context';
+import LoginPage from './LoginPage';
+
+const navigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => (
+    navigate
+  ),
+}));
+
+let loginErrorMessage;
+let login;
+jest.mock('../hooks/useUserStore', () => () => ({
+  loginErrorMessage,
+  login,
+}));
+
+// const register = jest.fn();
+// const handleSubmit = jest.fn();
+// jest.mock('react-hook-form', () => ({
+//   useForm: () => ({
+//     register,
+//     handleSubmit,
+//   }),
+// }));
+
+describe('LoginPage', () => {
+  const renderLoginPage = () => {
+    render((
+      <LoginPage />
+    ));
+  };
+
+  context('폼을 채우고 로그인 버튼을 누르면', () => {
+    login = jest.fn();
+
+    it('userStore의 login 메서드를 호출', async () => {
+      renderLoginPage();
+
+      fireEvent.change(screen.getByLabelText('아이디'), {
+        target: { value: 'hsjkdss228' },
+      });
+      fireEvent.change(screen.getByLabelText('비밀번호'), {
+        target: { value: 'Password!1' },
+      });
+
+      fireEvent.click(screen.getByText('로그인'));
+
+      await waitFor(() => {
+        expect(login).toBeCalledTimes(1);
+      });
+    });
+
+    context('로그인 결과로 Access Token이 반환되었으면', () => {
+      login = jest.fn(() => 'ACCESS TOKEN');
+
+      it('HomePage로 이동하는 navigate 함수 호출', async () => {
+        renderLoginPage();
+
+        fireEvent.change(screen.getByLabelText('아이디'), {
+          target: { value: 'hsjkdss228' },
+        });
+        fireEvent.change(screen.getByLabelText('비밀번호'), {
+          target: { value: 'Password!1' },
+        });
+
+        fireEvent.click(screen.getByText('로그인'));
+
+        await waitFor(() => {
+          expect(navigate).toBeCalledWith('/');
+        });
+      });
+    });
+  });
+});

--- a/src/services/UserApiService.js
+++ b/src/services/UserApiService.js
@@ -7,9 +7,9 @@ import config from '../config';
 const { apiBaseUrl } = config;
 
 export default class UserApiService {
-  async postSession(userId) {
+  async postSession({ identifier, password }) {
     const url = `${apiBaseUrl}/session`;
-    const { data } = await axios.post(url, { userId });
+    const { data } = await axios.post(url, { identifier, password });
     return data;
   }
 }

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -5,19 +5,12 @@ export default class UserStore extends Store {
   constructor() {
     super();
 
-    this.userId = '';
-    this.accessToken = '';
     this.loginErrorMessage = '';
   }
 
-  changeUserId(userId) {
-    this.userId = userId;
-    this.publish();
-  }
-
-  async login() {
+  async login({ identifier, password }) {
     try {
-      const data = await userApiService.postSession(this.userId);
+      const data = await userApiService.postSession({ identifier, password });
       this.accessToken = data.accessToken;
       return this.accessToken;
     } catch (error) {

--- a/src/stores/UserStore.test.js
+++ b/src/stores/UserStore.test.js
@@ -5,61 +5,63 @@ import { userApiService } from '../services/UserApiService';
 
 describe('UserStore', () => {
   let userStore;
-  let spyPublish;
   let spyPostSession;
-  let spyLogin;
+  // let spyLogin;
 
   beforeEach(() => {
     userStore = new UserStore();
-    spyPublish = jest.spyOn(userStore, 'publish');
     spyPostSession = jest.spyOn(userApiService, 'postSession');
-    spyLogin = jest.spyOn(userStore, 'login');
     jest.clearAllMocks();
   });
 
-  context('userId의 상태를 변경시키는 함수가 호출되면', () => {
-    it('userId의 상태를 변경하고 publish', () => {
-      expect(userStore.userId).toBe('');
-      userStore.changeUserId(2);
-      expect(userStore.userId).toBe(2);
-      expect(spyPublish).toBeCalled();
-    });
-  });
+  context('모든 정보를 정상적으로 입력하고 로그인 함수를 호출하면', () => {
+    const identifier = 'hsjkdss228';
+    const password = 'Password!1';
 
-  context('존재하는 userId로 로그인 함수가 호출되면', () => {
-    it('userApiService의 postSession을 호출하면서 저장된 userId의 상태를 전달해'
-      + '반환되는 Token 값을 상태로 저장 후 반환', async () => {
-      userStore.changeUserId(10);
-      await userStore.login();
-      expect(spyPostSession).toBeCalledWith(10);
+    it('userApiService의 postSession을 호출해 반환되는 Token 값을 반환', async () => {
+      await userStore.login({ identifier, password });
+      expect(spyPostSession).toBeCalledWith({ identifier, password });
       expect(userStore.accessToken).toBe('TOKEN');
-
-      expect(spyLogin).toReturn();
-      // TODO: accessToken까지 들고 return하는지까지는 확인할 수는 없는 걸까?
-      // expect(spyLogin).toReturnWith();
     });
   });
 
-  context('userId를 입력하지 않은 채로 로그인 함수가 호출되면', () => {
+  context('아이디를 입력하지 않고 로그인 함수를 호출하면', () => {
+    const identifier = '';
+    const password = 'Password!1';
+
     it('에러 메세지를 상태로 저장 후 반환', async () => {
-      await userStore.login();
-      expect(userStore.loginErrorMessage).toBe('user Id를 입력해주세요. (200)');
+      await userStore.login({ identifier, password });
+      expect(userStore.loginErrorMessage).toBe('아이디를 입력해주세요.');
     });
   });
 
-  context('존재하지 않는 userId로 로그인 함수가 호출되면', () => {
+  context('존재하지 않는 아이디를 입력하고 로그인 함수를 호출하면', () => {
+    const identifier = 'notexistingid12';
+    const password = 'Password!1';
+
     it('에러 메세지를 상태로 저장 후 반환', async () => {
-      userStore.changeUserId(4444);
-      await userStore.login();
-      expect(userStore.loginErrorMessage).toBe('존재하지 않는 user Id 입니다. (201)');
+      await userStore.login({ identifier, password });
+      expect(userStore.loginErrorMessage).toBe('존재하지 않는 아이디입니다.');
     });
   });
 
-  context('userId로 로그인 함수가 호출되었는데 인코딩 과정에서 문제가 발생했으면', () => {
+  context('비밀번호를 입력하지 않고 로그인 함수를 호출하면', () => {
+    const identifier = 'hsjkdss228';
+    const password = '';
+
     it('에러 메세지를 상태로 저장 후 반환', async () => {
-      userStore.changeUserId(1234);
-      await userStore.login();
-      expect(userStore.loginErrorMessage).toBe('user Id 인코딩 과정에서 문제가 발생했습니다. (202)');
+      await userStore.login({ identifier, password });
+      expect(userStore.loginErrorMessage).toBe('비밀번호를 입력해주세요.');
+    });
+  });
+
+  context('잘못된 비밀번호를 입력하고 로그인 함수를 호출하면', () => {
+    const identifier = 'hsjkdss228';
+    const password = 'wrongPassword!1';
+
+    it('에러 메세지를 상태로 저장 후 반환', async () => {
+      await userStore.login({ identifier, password });
+      expect(userStore.loginErrorMessage).toBe('비밀번호가 일치하지 않습니다.');
     });
   });
 });

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -130,9 +130,9 @@ const postTestServer = setupServer(
   rest.post(
     `${apiBaseUrl}/session`,
     async (request, response, context) => {
-      const { userId } = await request.json();
+      const { identifier, password } = await request.json();
 
-      if (userId === 10) {
+      if (identifier === 'hsjkdss228' && password === 'Password!1') {
         return response(
           context.status(201),
           context.json({
@@ -141,20 +141,38 @@ const postTestServer = setupServer(
         );
       }
 
-      if (userId === '') {
+      if (identifier === '' && password === 'Password!1') {
         return response(
           context.status(400),
           context.json({
-            errorMessage: 'user Id를 입력해주세요. (200)',
+            errorMessage: '아이디를 입력해주세요.',
           }),
         );
       }
 
-      if (userId === 1234) {
+      if (identifier === 'notexistingid12' && password === 'Password!1') {
         return response(
           context.status(400),
           context.json({
-            errorMessage: 'user Id 인코딩 과정에서 문제가 발생했습니다. (202)',
+            errorMessage: '존재하지 않는 아이디입니다.',
+          }),
+        );
+      }
+
+      if (identifier === 'hsjkdss228' && password === '') {
+        return response(
+          context.status(400),
+          context.json({
+            errorMessage: '비밀번호를 입력해주세요.',
+          }),
+        );
+      }
+
+      if (identifier === 'hsjkdss228' && password === 'wrongPassword!1') {
+        return response(
+          context.status(400),
+          context.json({
+            errorMessage: '비밀번호가 일치하지 않습니다.',
           }),
         );
       }
@@ -162,7 +180,7 @@ const postTestServer = setupServer(
       return response(
         context.status(400),
         context.json({
-          errorMessage: '존재하지 않는 user Id 입니다. (201)',
+          errorMessage: '알 수 없는 에러입니다.',
         }),
       );
     },


### PR DESCRIPTION
- 로그인 페이지를 새로 생성
  - 현재는 헤더에서 바로 로그인을 수행하고 있음
  - 헤더에 로그인 버튼만 남겨놓고, 클릭 시 로그인 페이지로 이동
  - 로그인을 하면 일단은 홈으로 이동하도록 구현
    (로그인을 클릭하던 시점에 있었던 페이지로 돌아가게 하는 작업은 나중에 구현)
  - 로그아웃 버튼을 누르면 마찬가지로 홈으로 이동

- 로그인 시 UseForm을 사용
  - useForm은 모킹하지 않고 그대로 쓰는 게 맞는 것 같다. (handleSubmit을 모킹하는 건 불가능한 것 같음)
  - await waitFor(() => {  })의 동작 원리를 파악할 필요가 있겠음
  - useForm에서 처리하는 예외와 백엔드에서 처리하는 예외를 모두 동일한 컴포넌트에서 받고, 프론트엔드 예외를 우선적으로 출력하는 방식으로 예외 메세지 안내 방식 구현  

예상 뽀모 7
실제 뽀모 9 (프론트엔드, 백엔드 통합)
  
![스크린샷 2022-11-23 오후 4 39 10](https://user-images.githubusercontent.com/50052512/203493657-04ae0d8a-70c2-4595-bf79-637c2d607d10.png)