### PR TITLE
날짜 선택, 시간 선택 오류 수정

### DIFF
--- a/src/components/PostForm.jsx
+++ b/src/components/PostForm.jsx
@@ -127,12 +127,14 @@ export default function PostForm({
             onChange={handleChangeGameStartHour}
             type="start"
             time="hour"
+            value={data.gameStartHour}
           />
           <SelectTime
             id="input-game-start-minute"
             onChange={handleChangeGameStartMinute}
             type="start"
             time="minute"
+            value={data.gameStartMinute}
           />
           <p>부터</p>
           <SelectTime
@@ -140,12 +142,14 @@ export default function PostForm({
             onChange={handleChangeGameEndHour}
             type="end"
             time="hour"
+            value={data.gameEndHour}
           />
           <SelectTime
             id="input-game-end-minute"
             onChange={handleChangeGameEndMinute}
             type="end"
             time="minute"
+            value={data.gameEndMinute}
           />
           <p>까지</p>
         </div>

--- a/src/components/PostForm.test.jsx
+++ b/src/components/PostForm.test.jsx
@@ -72,7 +72,7 @@ describe('PostForm', () => {
     context('각 입력 폼에 내용을 입력하면', () => {
       const dataWithSpecificDate = {
         gameExercise: '',
-        gameDate: new Date('2022-11-24T00:00:00.000Z'),
+        gameDate: new Date('2022-11-23T00:00:00.000Z'),
         gamePlace: '',
         gameTargetMemberCount: 0,
         postDetail: '',
@@ -89,9 +89,10 @@ describe('PostForm', () => {
         expect(changeGameExercise).toBeCalledWith('야구');
 
         fireEvent.change(screen.getByLabelText('날짜를 선택하세요:'), {
-          target: { value: '2022년 11월 25일' },
+          target: { value: '2022년 11월 24일' },
         });
-        expect(changeGameDate).toBeCalled();
+        expect(changeGameDate)
+          .toBeCalledWith(new Date('2022-11-24T00:00:00.000Z'));
 
         fireEvent.change(screen.getByLabelText(/start hour/), {
           target: { value: '05' },

--- a/src/components/SelectTime.jsx
+++ b/src/components/SelectTime.jsx
@@ -3,6 +3,7 @@ export default function SelectTime({
   onChange,
   type,
   time,
+  value,
 }) {
   return (
     <div>
@@ -13,10 +14,11 @@ export default function SelectTime({
       </label>
       <select
         id={id}
+        value={value}
         onChange={onChange}
       >
         <option
-          defaultValue
+          value=""
           disabled
           hidden
         >
@@ -24,23 +26,29 @@ export default function SelectTime({
         </option>
         {time === 'hour' ? (
           Array(12).fill(0).map((_, index) => {
-            const value = index + 1 < 10
+            const number = index + 1 < 10
               ? `0${index + 1}`
               : (index + 1).toString();
             return ((
-              <option key={value}>
-                {value}
+              <option
+                key={number}
+                value={number}
+              >
+                {number}
               </option>
             ));
           })
         ) : (
           Array(60).fill(0).map((_, index) => {
-            const value = index < 10
+            const number = index < 10
               ? `0${index}`
               : index.toString();
             return ((
-              <option key={value}>
-                {value}
+              <option
+                key={number}
+                value={number}
+              >
+                {number}
               </option>
             ));
           })

--- a/src/pages/PostFormPage.jsx
+++ b/src/pages/PostFormPage.jsx
@@ -9,6 +9,10 @@ export default function PostFormPage() {
 
   const {
     gameExercise,
+    gameStartHour,
+    gameStartMinute,
+    gameEndHour,
+    gameEndMinute,
     gameDate,
     gamePlace,
     gameTargetMemberCount,
@@ -17,6 +21,10 @@ export default function PostFormPage() {
 
   const data = {
     gameExercise,
+    gameStartHour,
+    gameStartMinute,
+    gameEndHour,
+    gameEndMinute,
     gameDate,
     gamePlace,
     gameTargetMemberCount,

--- a/src/pages/PostFormPage.test.jsx
+++ b/src/pages/PostFormPage.test.jsx
@@ -60,7 +60,7 @@ describe('PostFormPage', () => {
   context('게시글 작성하기 페이지에 접속해 각 입력 폼의 내용을 수정하면', () => {
     beforeEach(() => {
       gameExercise = '';
-      gameDate = new Date();
+      gameDate = new Date('2022-11-23T00:00:00.000Z');
       gamePlace = '';
       gameTargetMemberCount = 0;
       postDetail = '';
@@ -75,9 +75,10 @@ describe('PostFormPage', () => {
       expect(changeGameExercise).toBeCalledWith('야구');
 
       fireEvent.change(screen.getByLabelText('날짜를 선택하세요:'), {
-        target: { value: '2022년 11월 25일' },
+        target: { value: '2022년 11월 24일' },
       });
-      expect(changeGameDate).toBeCalled();
+      expect(changeGameDate)
+        .toBeCalledWith(new Date('2022-11-24T00:00:00.000Z'));
 
       fireEvent.change(screen.getByLabelText(/start hour/), {
         target: { value: '05' },

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -44,6 +44,7 @@ export default class PostApiService {
     postDetail,
   }) {
     const url = `${apiBaseUrl}/posts`;
+    console.log(gameTime);
     const { data } = await axios.post(url, {
       gameExercise,
       gameDate,

--- a/src/stores/PostFormStore.js
+++ b/src/stores/PostFormStore.js
@@ -71,7 +71,7 @@ export default class PostFormStore extends Store {
       const gameTime = `${this.gameStartHour},${this.gameStartMinute},${this.gameEndHour},${this.gameEndMinute}`;
       const data = await postApiService.createPost({
         gameExercise: this.gameExercise,
-        gameDate: this.gameDate,
+        gameDate: this.gameDate.toISOString(),
         gameTime,
         gamePlace: this.gamePlace,
         gameTargetMemberCount: this.gameTargetMemberCount,

--- a/src/stores/PostFormStore.test.js
+++ b/src/stores/PostFormStore.test.js
@@ -8,15 +8,25 @@ describe('PostFormStore', () => {
 
   // TODO: change 계열 메서드 호출 시 상태 변경 검증
 
-  context('게시글 생성 API에 상태로 저장하고 있는 데이터를 전달해 호출하면', () => {
-    beforeEach(() => {
-      postFormStore = new PostFormStore();
-    });
+  beforeEach(() => {
+    postFormStore = new PostFormStore();
+  });
 
+  context('상태 변경 함수가 호출되면', () => {
+    const date = new Date('2022-11-26T00:00:00.000Z');
+    it('받아온 값을 상태에 반영 후 publish', () => {
+      postFormStore.changeGameDate(date);
+
+      const { gameDate } = postFormStore;
+      expect(gameDate).toStrictEqual(new Date('2022-11-26T00:00:00.000Z'));
+    });
+  });
+
+  context('게시글 생성 API에 상태로 저장하고 있는 데이터를 전달해 호출하면', () => {
     it('생성된 게시글 id를 반환해 반환', async () => {
       postApiService.setAccessToken('userId 1');
       postFormStore.gameExercise = '스케이트';
-      postFormStore.gameDate = '2022년 12월 31일';
+      postFormStore.gameDate = new Date('2022-12-31T00:00:00.000Z');
       postFormStore.gameStartHour = '10';
       postFormStore.gameStartMinute = '00';
       postFormStore.gameEndHour = '12';

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -348,7 +348,7 @@ const postTestServer = setupServer(
         .substring('bearer '.length);
 
       if (gameExercise === '스케이트'
-        && gameDate === '2022년 12월 31일'
+        && gameDate === new Date('2022-12-31T00:00:00.000Z').toISOString()
         && gameTime === '10,00,12,30'
         && gamePlace === '롯데월드 아이스링크'
         && gameTargetMemberCount === '12'


### PR DESCRIPTION
문제상황
- Store에 0000년 00월 00일로 날짜를 전달한다고 생각했는데 new Date() 값으로 전달되고 있었고, DTO에서 String 형태로는 값을 받을 수 없어 null이 전달되고 있었음
  - 상태에 저장되는 값을 String으로 바꿔서 값을 저장하게 할 경우 UI에서 받아야 하는 DatePicker의 value가 Date 타입이 아니게 되므로 프론트엔드에서 상태는 Date 타입으로 갖고 있게 한 뒤,  API 요청을 보낼 때만 .toISOString() 메서드를 이용해 문자열 형태로 변환해 전송, GameDateTime 메서드가 파싱하는 동작도 ISOString 형태의 문자열을 파싱하는 구조로 변경
- 분으로 00을 선택했을 경우 누락되고 있었음
  - 첫 번째 '선택' 이름을 비롯해 숫자 옵션들에 value 속성이 존재하지 않았음, 첫 번째 선택 value 속성에는 빈 값을, 다른 숫자들의 value 속성에는 자기자신의 숫자 값을 주었음
  - select 속성에도 value가 존재하지 않았음, 선택한 option 속성의 value 값을 select의 value로 줘서 해당 드롭다운 필드도 다른 input 필드처럼 값을 갖고, store에 저장된 상태를 select의 value로 전달하도록 변경