### PR TITLE
잔여석이 없는 경우 대체 메세지 출력, 신청 시 잔여석이 없을 경우 예외처리

### DIFF
--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-nested-ternary */
+
 import styled from 'styled-components';
 import PostGameInformation from './PostGameInformation';
 import PostGameMemberInformation from './PostGameMembersInformation';
@@ -42,6 +44,7 @@ export default function Post({
   handleClickParticipateCancel,
   acceptRegister,
   rejectRegister,
+  registerError,
 }) {
   const onClickBackward = () => {
     navigateToBackward();
@@ -118,10 +121,13 @@ export default function Post({
           />
         ) : (
           <PostRegisterButton
+            currentMemberCount={game.currentMemberCount}
+            targetMemberCount={game.targetMemberCount}
             registerStatus={game.registerStatus}
             onClickRegister={onClickRegister}
             onClickRegisterCancel={onClickRegisterCancel}
             onClickParticipateCancel={onClickParticipateCancel}
+            registerError={registerError}
           />
         )}
       </PostInformation>

--- a/src/components/Post.test.jsx
+++ b/src/components/Post.test.jsx
@@ -8,12 +8,15 @@ describe('Post', () => {
   const handleClickRegister = jest.fn();
   const handleClickRegisterCancel = jest.fn();
   const handleClickParticipateCancel = jest.fn();
+  const acceptRegister = jest.fn();
+  const rejectRegister = jest.fn();
 
   const renderPost = ({
     post,
     game,
     members,
     applicants,
+    registerError,
   }) => {
     render((
       <Post
@@ -26,6 +29,9 @@ describe('Post', () => {
         handleClickRegister={handleClickRegister}
         handleClickRegisterCancel={handleClickRegisterCancel}
         handleClickParticipateCancel={handleClickParticipateCancel}
+        acceptRegister={acceptRegister}
+        rejectRegister={rejectRegister}
+        registerError={registerError}
       />
     ));
   };
@@ -35,6 +41,7 @@ describe('Post', () => {
     const game = {};
     const members = [];
     const applicants = [];
+    const registerError = {};
 
     it('게시글 정보를 불러오고 있다는 메세지 출력', () => {
       renderPost({
@@ -42,6 +49,7 @@ describe('Post', () => {
         game,
         members,
         applicants,
+        registerError,
       });
 
       screen.getByText('정보를 불러오고 있습니다...');
@@ -79,6 +87,7 @@ describe('Post', () => {
       },
     ];
     const applicants = [];
+    const registerError = {};
 
     it('뒤로가기 navigate 함수를 호출하는 핸들러 함수 호출', () => {
       renderPost({
@@ -86,6 +95,7 @@ describe('Post', () => {
         game,
         members,
         applicants,
+        registerError,
       });
 
       fireEvent.click(screen.getByText('⬅️'));
@@ -122,6 +132,7 @@ describe('Post', () => {
       },
     ];
     const applicants = [];
+    const registerError = {};
 
     it('해당 게임에 참가를 신청하는 운동 참가 신청 핸들러 함수 호출', () => {
       renderPost({
@@ -129,6 +140,7 @@ describe('Post', () => {
         game,
         members,
         applicants,
+        registerError,
       });
 
       fireEvent.click(screen.getByText('신청'));
@@ -171,6 +183,7 @@ describe('Post', () => {
       },
     ];
     const applicants = [];
+    const registerError = {};
 
     it('해당 게임 참가 신청을 취소하는 운동 참가 신청 취소 핸들러 함수 호출', () => {
       renderPost({
@@ -178,6 +191,7 @@ describe('Post', () => {
         game,
         members,
         applicants,
+        registerError,
       });
 
       fireEvent.click(screen.getByText('신청취소'));
@@ -220,6 +234,7 @@ describe('Post', () => {
       },
     ];
     const applicants = [];
+    const registerError = {};
 
     it('해당 게임 참가 신청을 취소하는 운동 참가 신청 취소 핸들러 함수 호출', () => {
       renderPost({
@@ -227,6 +242,7 @@ describe('Post', () => {
         game,
         members,
         applicants,
+        registerError,
       });
 
       fireEvent.click(screen.getByText('참가취소'));
@@ -263,6 +279,7 @@ describe('Post', () => {
       },
     ];
     const applicants = [];
+    const registerError = {};
 
     it('게시글 삭제하기 버튼을 확인할 수 없음', () => {
       renderPost({
@@ -270,6 +287,7 @@ describe('Post', () => {
         game,
         members,
         applicants,
+        registerError,
       });
 
       expect(screen.queryByText('삭제하기')).toBe(null);
@@ -304,6 +322,7 @@ describe('Post', () => {
       },
     ];
     const applicants = [];
+    const registerError = {};
 
     it('게시글 삭제하기 버튼을 확인할 수 있음', () => {
       renderPost({
@@ -311,6 +330,7 @@ describe('Post', () => {
         game,
         members,
         applicants,
+        registerError,
       });
 
       screen.getByText('삭제하기');
@@ -323,6 +343,7 @@ describe('Post', () => {
           game,
           members,
           applicants,
+          registerError,
         });
 
         fireEvent.click(screen.getByText('삭제하기'));

--- a/src/components/PostRegisterButton.jsx
+++ b/src/components/PostRegisterButton.jsx
@@ -17,21 +17,38 @@ const Button = styled.button`
 `;
 
 export default function PostRegisterButton({
+  currentMemberCount,
+  targetMemberCount,
   registerStatus,
   onClickRegister,
   onClickRegisterCancel,
   onClickParticipateCancel,
+  registerError,
 }) {
+  if (registerStatus === 'none'
+    && currentMemberCount >= targetMemberCount) {
+    return (
+      <p>참가 정원이 모두 찼습니다.</p>
+    );
+  }
+
   if (registerStatus === 'none') {
     return (
-      <RegisterButtonSection>
-        <Button
-          type="button"
-          onClick={onClickRegister}
-        >
-          신청
-        </Button>
-      </RegisterButtonSection>
+      <>
+        <RegisterButtonSection>
+          <Button
+            type="button"
+            onClick={onClickRegister}
+          >
+            신청
+          </Button>
+        </RegisterButtonSection>
+        {registerError.errorCode ? (
+          <p>{registerError.errorMessage}</p>
+        ) : (
+          null
+        )}
+      </>
     );
   }
 

--- a/src/components/PostRegisterButton.test.jsx
+++ b/src/components/PostRegisterButton.test.jsx
@@ -7,29 +7,50 @@ describe('PostRegisterButton', () => {
   const onClickRegisterCancel = jest.fn();
   const onClickParticipateCancel = jest.fn();
 
-  const renderPostRegisterButton = ({ registerStatus }) => {
+  const renderPostRegisterButton = ({
+    currentMemberCount,
+    targetMemberCount,
+    registerStatus,
+    registerError,
+  }) => {
     render((
       <PostRegisterButton
+        currentMemberCount={currentMemberCount}
+        targetMemberCount={targetMemberCount}
         registerStatus={registerStatus}
         onClickRegister={onClickRegister}
         onClickRegisterCancel={onClickRegisterCancel}
         onClickParticipateCancel={onClickParticipateCancel}
+        registerError={registerError}
       />
     ));
   };
 
   context('사용자가 게시글의 게임에 참가 신청을 하지 않았거나, 취소했거나, 거절당했었을 경우', () => {
+    const currentMemberCount = 4;
+    const targetMemberCount = 6;
     const registerStatus = 'none';
+    const registerError = {};
 
     it('신청 버튼 출력', () => {
-      renderPostRegisterButton({ registerStatus });
+      renderPostRegisterButton({
+        currentMemberCount,
+        targetMemberCount,
+        registerStatus,
+        registerError,
+      });
 
       screen.getByText('신청');
     });
 
     context('신청 버튼을 클릭하면', () => {
       it('운동 참가 신청 핸들러 함수 호출', () => {
-        renderPostRegisterButton({ registerStatus });
+        renderPostRegisterButton({
+          currentMemberCount,
+          targetMemberCount,
+          registerStatus,
+          registerError,
+        });
 
         fireEvent.click(screen.getByText('신청'));
         expect(onClickRegister).toBeCalled();
@@ -38,17 +59,30 @@ describe('PostRegisterButton', () => {
   });
 
   context('사용자가 게시글의 게임에 참가 신청을 한 상태인 경우', () => {
+    const currentMemberCount = 4;
+    const targetMemberCount = 6;
     const registerStatus = 'processing';
+    const registerError = {};
 
     it('신청취소 버튼 출력', () => {
-      renderPostRegisterButton({ registerStatus });
+      renderPostRegisterButton({
+        currentMemberCount,
+        targetMemberCount,
+        registerStatus,
+        registerError,
+      });
 
       screen.getByText('신청취소');
     });
 
     context('신청취소 버튼을 클릭하면', () => {
       it('운동 참가 신청 취소 핸들러 함수 호출', () => {
-        renderPostRegisterButton({ registerStatus });
+        renderPostRegisterButton({
+          currentMemberCount,
+          targetMemberCount,
+          registerStatus,
+          registerError,
+        });
 
         fireEvent.click(screen.getByText('신청취소'));
         expect(onClickRegisterCancel).toBeCalled();
@@ -57,21 +91,74 @@ describe('PostRegisterButton', () => {
   });
 
   context('사용자가 게시글의 게임에 참가하는 상태인 경우', () => {
+    const currentMemberCount = 4;
+    const targetMemberCount = 6;
     const registerStatus = 'accepted';
+    const registerError = {};
 
     it('참가취소 버튼 출력', () => {
-      renderPostRegisterButton({ registerStatus });
+      renderPostRegisterButton({
+        currentMemberCount,
+        targetMemberCount,
+        registerStatus,
+        registerError,
+      });
 
       screen.getByText('참가취소');
     });
 
     context('참가취소 버튼을 클릭하면', () => {
       it('운동 참가 취소 핸들러 함수 호출', () => {
-        renderPostRegisterButton({ registerStatus });
+        renderPostRegisterButton({
+          currentMemberCount,
+          targetMemberCount,
+          registerStatus,
+          registerError,
+        });
 
         fireEvent.click(screen.getByText('참가취소'));
         expect(onClickParticipateCancel).toBeCalled();
       });
+    });
+  });
+
+  context('게시글에 신청하지 않은 상태에서 정원이 가득 찬 상태인 경우', () => {
+    const currentMemberCount = 6;
+    const targetMemberCount = 6;
+    const registerStatus = 'none';
+    const registerError = {};
+
+    it('버튼 대신 정원이 가득 찼다는 메시지 출력', () => {
+      renderPostRegisterButton({
+        currentMemberCount,
+        targetMemberCount,
+        registerStatus,
+        registerError,
+      });
+
+      screen.getByText('참가 정원이 모두 찼습니다.');
+    });
+  });
+
+  context('정원이 가득 찼다는 에러 메세지가 전달되었을 경우', () => {
+    const currentMemberCount = 5;
+    const targetMemberCount = 6;
+    const registerStatus = 'none';
+    const registerError = {
+      errorCode: 100,
+      errorMessage: '참가 정원이 모두 차 참가를 신청할 수 없습니다.',
+    };
+
+    it('버튼 아래에 에러 메세지를 출력', () => {
+      renderPostRegisterButton({
+        currentMemberCount,
+        targetMemberCount,
+        registerStatus,
+        registerError,
+      });
+
+      screen.getByText('신청');
+      screen.getByText('참가 정원이 모두 차 참가를 신청할 수 없습니다.');
     });
   });
 });

--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -30,7 +30,7 @@ export default function Posts({
   cancelRegisterToGame,
   cancelParticipateToGame,
   postsErrorMessage,
-  registerErrorCodeAndMessage,
+  registerErrors,
 }) {
   const onClickBackward = () => {
     navigateToBackward();
@@ -76,23 +76,19 @@ export default function Posts({
               post.isAuthor ? (
                 null
               ) : (
-                <>
+                <div>
                   <PostsRegisterButton
                     gameId={post.game.id}
                     registerId={post.game.registerId}
+                    currentMemberCount={post.game.currentMemberCount}
+                    targetMemberCount={post.game.targetMemberCount}
                     registerStatus={post.game.registerStatus}
                     registerToGame={registerToGame}
                     cancelRegisterToGame={cancelRegisterToGame}
                     cancelParticipateToGame={cancelParticipateToGame}
+                    registerErrors={registerErrors}
                   />
-                  {registerErrorCodeAndMessage.message ? (
-                    <p>
-                      {registerErrorCodeAndMessage.message}
-                    </p>
-                  ) : (
-                    null
-                  )}
-                </>
+                </div>
               )
             }
           </Thumbnail>

--- a/src/components/Posts.test.jsx
+++ b/src/components/Posts.test.jsx
@@ -67,13 +67,14 @@ describe('Posts', () => {
         hits: 334,
         isAuthor: false,
         game: {
+          id: 2,
           type: '배드민턴',
           date: '2022년 10월 24일 13:00~16:00',
           place: '올림픽공원 핸드볼경기장',
           currentMemberCount: 4,
           targetMemberCount: 5,
-          registerId: 10,
-          registerStatus: 'accepted',
+          registerId: -1,
+          registerStatus: 'none',
         },
       },
     ];
@@ -105,8 +106,9 @@ describe('Posts', () => {
 
     it('사용자가 버튼을 클릭하고 나서 에러가 전달되었을 시 에러 메세지를 출력', () => {
       const codeAndMessage = {
-        code: 100,
-        message: '에러 메세지 내용입니다.',
+        errorCode: 100,
+        errorMessage: '에러 메세지 내용입니다.',
+        gameId: 2,
       };
 
       renderPosts({
@@ -126,6 +128,7 @@ describe('Posts', () => {
         hits: 334,
         isAuthor: true,
         game: {
+          id: 2,
           type: '주짓수',
           date: '2022년 10월 31일 08:00~11:00',
           place: '팀 레드 주짓수&MMA',

--- a/src/components/Posts.test.jsx
+++ b/src/components/Posts.test.jsx
@@ -12,7 +12,7 @@ describe('Posts', () => {
   const renderPosts = ({
     posts,
     postsErrorMessage,
-    registerErrorCodeAndMessage,
+    registerErrors,
   }) => {
     render((
       <Posts
@@ -23,7 +23,7 @@ describe('Posts', () => {
         cancelRegisterToGame={cancelRegisterToGame}
         cancelParticipateToGame={cancelParticipateToGame}
         postsErrorMessage={postsErrorMessage}
-        registerErrorCodeAndMessage={registerErrorCodeAndMessage}
+        registerErrors={registerErrors}
       />
     ));
   };
@@ -31,13 +31,13 @@ describe('Posts', () => {
   context('등록된 게시글이 존재하지 않는 경우', () => {
     const posts = [];
     const postsErrorMessage = '';
-    const registerErrorCodeAndMessage = {};
+    const registerErrors = {};
 
     it('게시물 미존재 안내 메세지 출력', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrorCodeAndMessage,
+        registerErrors,
       });
 
       screen.getByText(/등록된 게시물이 존재하지 않습니다./);
@@ -47,13 +47,13 @@ describe('Posts', () => {
   context('게임이 찾아지지 않은 에러가 발생한 경우', () => {
     const posts = [];
     const postsErrorMessage = '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.';
-    const registerErrorCodeAndMessage = {};
+    const registerErrors = {};
 
     it('에러 메세지 출력', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrorCodeAndMessage,
+        registerErrors,
       });
 
       screen.getByText(/주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다./);
@@ -78,13 +78,13 @@ describe('Posts', () => {
       },
     ];
     const postsErrorMessage = '';
-    const registerErrorCodeAndMessage = {};
+    const registerErrors = {};
 
     it('뒤로가기 버튼을 누를 시 뒤로가기로 이동하는 navigate 함수 호출', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrorCodeAndMessage,
+        registerErrors,
       });
 
       fireEvent.click(screen.getByText('⬅️'));
@@ -95,7 +95,7 @@ describe('Posts', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrorCodeAndMessage,
+        registerErrors,
       });
 
       fireEvent.click(screen.getByText('배드민턴'));
@@ -112,7 +112,7 @@ describe('Posts', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrorCodeAndMessage: codeAndMessage,
+        registerErrors: codeAndMessage,
       });
 
       screen.getByText(/에러 메세지 내용입니다./);
@@ -137,13 +137,13 @@ describe('Posts', () => {
       },
     ];
     const postsErrorMessage = '';
-    const registerErrorCodeAndMessage = {};
+    const registerErrors = {};
 
     it('해당 게시글 리스트 제목 옆에 신청/취소/참가취소 버튼이 나타나지 않음', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrorCodeAndMessage,
+        registerErrors,
       });
 
       expect(screen.queryByText('신청')).toBeNull();

--- a/src/components/PostsRegisterButton.jsx
+++ b/src/components/PostsRegisterButton.jsx
@@ -47,9 +47,6 @@ export default function PostsRegisterButton({
   }
 
   if (registerStatus === 'none') {
-    console.log('gameId', gameId);
-    console.log('registeredGameId', registerErrors.gameId);
-
     return (
       <>
         <RegisterButtonSection>
@@ -62,11 +59,12 @@ export default function PostsRegisterButton({
             신청
           </Button>
         </RegisterButtonSection>
-        {registerErrors.errorCode && gameId === registerErrors.gameId ? (
-          <p>{registerErrors.errorMessage}</p>
-        ) : (
-          null
-        )}
+        {registerErrors.errorCode
+          && gameId === registerErrors.gameId ? (
+            <p>{registerErrors.errorMessage}</p>
+          ) : (
+            null
+          )}
       </>
     );
   }

--- a/src/components/PostsRegisterButton.jsx
+++ b/src/components/PostsRegisterButton.jsx
@@ -20,9 +20,12 @@ export default function PostsRegisterButton({
   gameId,
   registerId,
   registerStatus,
+  currentMemberCount,
+  targetMemberCount,
   registerToGame,
   cancelRegisterToGame,
   cancelParticipateToGame,
+  registerErrors,
 }) {
   const handleClickRegister = (targetGameId) => {
     registerToGame(targetGameId);
@@ -36,18 +39,35 @@ export default function PostsRegisterButton({
     cancelParticipateToGame(targetRegisterId);
   };
 
-  if (registerStatus === 'none') {
+  if (registerStatus === 'none'
+    && currentMemberCount >= targetMemberCount) {
     return (
-      <RegisterButtonSection>
-        <p>바로 신청하고 싶다면?</p>
-        <Button
-          id={`posts-register-button-${gameId}`}
-          type="button"
-          onClick={() => handleClickRegister(gameId)}
-        >
-          신청
-        </Button>
-      </RegisterButtonSection>
+      null
+    );
+  }
+
+  if (registerStatus === 'none') {
+    console.log('gameId', gameId);
+    console.log('registeredGameId', registerErrors.gameId);
+
+    return (
+      <>
+        <RegisterButtonSection>
+          <p>바로 신청하고 싶다면?</p>
+          <Button
+            id={`posts-register-button-${gameId}`}
+            type="button"
+            onClick={() => handleClickRegister(gameId)}
+          >
+            신청
+          </Button>
+        </RegisterButtonSection>
+        {registerErrors.errorCode && gameId === registerErrors.gameId ? (
+          <p>{registerErrors.errorMessage}</p>
+        ) : (
+          null
+        )}
+      </>
     );
   }
 

--- a/src/components/PostsRegisterButton.test.jsx
+++ b/src/components/PostsRegisterButton.test.jsx
@@ -11,15 +11,21 @@ describe('PostsRegisterButton', () => {
     gameId,
     registerId,
     registerStatus,
+    currentMemberCount,
+    targetMemberCount,
+    registerErrors,
   }) => {
     render((
       <PostsRegisterButton
         gameId={gameId}
         registerId={registerId}
         registerStatus={registerStatus}
+        currentMemberCount={currentMemberCount}
+        targetMemberCount={targetMemberCount}
         registerToGame={registerToGame}
         cancelRegisterToGame={cancelRegisterToGame}
         cancelParticipateToGame={cancelParticipateToGame}
+        registerErrors={registerErrors}
       />
     ));
   };
@@ -28,6 +34,9 @@ describe('PostsRegisterButton', () => {
     const gameId = 2;
     const registerId = -1;
     const registerStatus = 'none';
+    const currentMemberCount = 5;
+    const targetMemberCount = 10;
+    const registerErrors = {};
 
     it('운동 참가 신청 이벤트 핸들러 호출', () => {
       jest.clearAllMocks();
@@ -35,6 +44,9 @@ describe('PostsRegisterButton', () => {
         gameId,
         registerId,
         registerStatus,
+        currentMemberCount,
+        targetMemberCount,
+        registerErrors,
       });
 
       fireEvent.click(screen.getByText('신청'));
@@ -46,6 +58,9 @@ describe('PostsRegisterButton', () => {
     const gameId = 2;
     const registerId = 7;
     const registerStatus = 'processing';
+    const currentMemberCount = 5;
+    const targetMemberCount = 10;
+    const registerErrors = {};
 
     it('운동 참가 취소 이벤트 핸들러 호출', () => {
       jest.clearAllMocks();
@@ -53,6 +68,9 @@ describe('PostsRegisterButton', () => {
         gameId,
         registerId,
         registerStatus,
+        currentMemberCount,
+        targetMemberCount,
+        registerErrors,
       });
 
       fireEvent.click(screen.getByText('신청취소'));
@@ -64,16 +82,70 @@ describe('PostsRegisterButton', () => {
     const gameId = 2;
     const registerId = 7;
     const registerStatus = 'accepted';
+    const currentMemberCount = 5;
+    const targetMemberCount = 10;
+    const registerErrors = {};
 
     it('에러 메세지 출력', () => {
       renderPostsRegisterButton({
         gameId,
         registerId,
         registerStatus,
+        currentMemberCount,
+        targetMemberCount,
+        registerErrors,
       });
 
       fireEvent.click(screen.getByText('참가취소'));
       expect(cancelParticipateToGame).toBeCalledWith(registerId);
+    });
+  });
+
+  context('신청하지 않은 상태인데 잔여석이 없을 경우', () => {
+    const gameId = 2;
+    const registerId = 7;
+    const registerStatus = 'none';
+    const currentMemberCount = 10;
+    const targetMemberCount = 10;
+    const registerErrors = {};
+
+    it('신청 버튼을 출력하지 않음', () => {
+      renderPostsRegisterButton({
+        gameId,
+        registerId,
+        registerStatus,
+        currentMemberCount,
+        targetMemberCount,
+        registerErrors,
+      });
+
+      expect(screen.queryByText('바로 신청하고 싶다면?')).toBe(null);
+    });
+  });
+
+  context('에러 메세지가 전달될 경우', () => {
+    const gameId = 2;
+    const registerId = 7;
+    const registerStatus = 'none';
+    const currentMemberCount = 9;
+    const targetMemberCount = 10;
+    const registerErrors = {
+      errorCode: '100',
+      errorMessage: '에러 메세지 내용입니다.',
+      gameId: 2,
+    };
+
+    it('버튼 하단에 에러 메세지를 출력', () => {
+      renderPostsRegisterButton({
+        gameId,
+        registerId,
+        registerStatus,
+        currentMemberCount,
+        targetMemberCount,
+        registerErrors,
+      });
+
+      screen.getByText('에러 메세지 내용입니다.');
     });
   });
 });

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -39,7 +39,11 @@ export default function PostPage() {
 
   const { post } = postStore;
   const { game } = gameStore;
-  const { members, applicants } = registerStore;
+  const {
+    members,
+    applicants,
+    registerErrorCodeAndMessage,
+  } = registerStore;
 
   const navigateToBackward = () => {
     navigate(-1);
@@ -90,6 +94,7 @@ export default function PostPage() {
       handleClickParticipateCancel={handleClickParticipateCancel}
       acceptRegister={acceptRegister}
       rejectRegister={rejectRegister}
+      registerError={registerErrorCodeAndMessage}
     />
   );
 }

--- a/src/pages/PostPage.test.jsx
+++ b/src/pages/PostPage.test.jsx
@@ -35,6 +35,7 @@ jest.mock('../hooks/useGameStore', () => () => ({
 
 let members;
 let applicants;
+let registerErrorCodeAndMessage;
 const fetchMembers = jest.fn();
 const fetchApplicants = jest.fn();
 let registerToGame;
@@ -45,6 +46,7 @@ const rejectRegister = jest.fn();
 jest.mock('../hooks/useRegisterStore', () => () => ({
   members,
   applicants,
+  registerErrorCodeAndMessage,
   fetchMembers,
   fetchApplicants,
   registerToGame,
@@ -92,6 +94,7 @@ describe('PostPage', () => {
             phoneNumber: '010-6877-2291',
           },
         ];
+        registerErrorCodeAndMessage = {};
       });
 
       it('운동 모집 게시글 상세 정보 상태들을 PostStore, '
@@ -142,6 +145,7 @@ describe('PostPage', () => {
             phoneNumber: '010-6877-2291',
           },
         ];
+        registerErrorCodeAndMessage = {};
       });
 
       it('해당 게임에 참가를 신청하는 운동 참가 신청 함수 호출 후, '
@@ -202,6 +206,7 @@ describe('PostPage', () => {
             phoneNumber: '010-5555-5555',
           },
         ];
+        registerErrorCodeAndMessage = {};
       });
 
       it('해당 신청의 상태를 변경하는 운동 참가 신청 취소 함수 호출 후, '
@@ -261,6 +266,7 @@ describe('PostPage', () => {
             phoneNumber: '010-8765-4321',
           },
         ];
+        registerErrorCodeAndMessage = {};
       });
 
       it('해당 신청의 상태를 변경하는 운동 참가 취소 함수 호출 후, '
@@ -323,6 +329,7 @@ describe('PostPage', () => {
           phoneNumber: '010-2424-2424',
         },
       ];
+      registerErrorCodeAndMessage = {};
     });
 
     it('운동 모집 게시글 상세 정보 및 신청자 정보 상태들을 PostStore, '

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -21,6 +21,7 @@ export default function PostsPage() {
   }, [accessToken]);
 
   const { posts, postsErrorMessage } = postStore;
+  const { registerErrorCodeAndMessage } = registerStore;
 
   const navigateToBackward = () => {
     navigate(-1);
@@ -51,8 +52,6 @@ export default function PostsPage() {
     await postStore.fetchPosts();
   };
 
-  const { registerErrorCodeAndMessage } = registerStore;
-
   return (
     <Posts
       posts={posts}
@@ -62,7 +61,7 @@ export default function PostsPage() {
       cancelRegisterToGame={cancelRegisterToGame}
       cancelParticipateToGame={cancelParticipateToGame}
       postsErrorMessage={postsErrorMessage}
-      registerErrorCodeAndMessage={registerErrorCodeAndMessage}
+      registerErrors={registerErrorCodeAndMessage}
     />
   );
 }

--- a/src/stores/RegisterStore.js
+++ b/src/stores/RegisterStore.js
@@ -46,11 +46,13 @@ export default class RegisterStore extends Store {
       this.registeredGameId = await registerApiService.registerToGame(gameId);
       return this.registeredGameId;
     } catch (error) {
-      const { errorCode, errorMessage } = error.response.data;
+      const { errorCode, errorMessage, gameId } = error.response.data;
       this.registerErrorCodeAndMessage = {
-        code: errorCode,
-        message: errorMessage,
+        errorCode,
+        errorMessage,
+        gameId,
       };
+      this.publish();
       return '';
     }
   }

--- a/src/stores/RegisterStore.test.js
+++ b/src/stores/RegisterStore.test.js
@@ -66,8 +66,8 @@ describe('RegisterStore', () => {
 
       expect(registeredGameId).toBe(-1);
       expect(registerErrorCodeAndMessage).toStrictEqual({
-        code: 100,
-        message: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
+        errorCode: 100,
+        errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
       });
     });
   });
@@ -82,8 +82,8 @@ describe('RegisterStore', () => {
 
       expect(registeredGameId).toBe(-1);
       expect(registerErrorCodeAndMessage).toStrictEqual({
-        code: 101,
-        message: '이미 신청이 완료된 운동입니다.',
+        errorCode: 101,
+        errorMessage: '이미 신청이 완료된 운동입니다.',
       });
     });
   });
@@ -98,8 +98,8 @@ describe('RegisterStore', () => {
 
       expect(registeredGameId).toBe(-1);
       expect(registerErrorCodeAndMessage).toStrictEqual({
-        code: 102,
-        message: '주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다.',
+        errorCode: 102,
+        errorMessage: '주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다.',
       });
     });
   });

--- a/src/stores/RegisterStore.test.js
+++ b/src/stores/RegisterStore.test.js
@@ -68,6 +68,7 @@ describe('RegisterStore', () => {
       expect(registerErrorCodeAndMessage).toStrictEqual({
         errorCode: 100,
         errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
+        gameId: null,
       });
     });
   });
@@ -83,7 +84,8 @@ describe('RegisterStore', () => {
       expect(registeredGameId).toBe(-1);
       expect(registerErrorCodeAndMessage).toStrictEqual({
         errorCode: 101,
-        errorMessage: '이미 신청이 완료된 운동입니다.',
+        errorMessage: '이미 신청 중이거나 신청이 완료된 운동입니다.',
+        gameId: null,
       });
     });
   });
@@ -91,15 +93,39 @@ describe('RegisterStore', () => {
   context('존재하지 않는 user Id로 운동 참가 신청 API를 요청할 경우', () => {
     it('사용자를 찾을 수 없다는 에러 상태 저장', async () => {
       registerApiService.setAccessToken('not existed userId 3');
-      const gameId = 1;
-      await registerStore.registerToGame(gameId);
+      const targetGameId = 1;
+      await registerStore.registerToGame(targetGameId);
 
-      const { registeredGameId, registerErrorCodeAndMessage } = registerStore;
+      const {
+        registeredGameId,
+        registerErrorCodeAndMessage,
+      } = registerStore;
 
       expect(registeredGameId).toBe(-1);
       expect(registerErrorCodeAndMessage).toStrictEqual({
         errorCode: 102,
         errorMessage: '주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다.',
+        gameId: null,
+      });
+    });
+
+    context('user Id로 운동 참가 신청 API를 요청했지만 정원이 마감된 경우', () => {
+      it('참가 정원이 모두 차 참가를 신청할 수 없다는 에러 상태 저장', async () => {
+        registerApiService.setAccessToken('fully participated userId 3');
+        const targetGameId = 1;
+        await registerStore.registerToGame(targetGameId);
+
+        const {
+          registeredGameId,
+          registerErrorCodeAndMessage,
+        } = registerStore;
+
+        expect(registeredGameId).toBe(-1);
+        expect(registerErrorCodeAndMessage).toStrictEqual({
+          errorCode: 103,
+          errorMessage: '참가 정원이 모두 차 참가를 신청할 수 없습니다.',
+          gameId: 1,
+        });
       });
     });
   });

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -23,6 +23,7 @@ const postTestServer = setupServer(
               hits: 334,
               isAuthor: false,
               game: {
+                id: 1,
                 type: '축구',
                 date: '2022년 10월 19일 13:00~16:00',
                 place: '대전월드컵경기장',
@@ -37,6 +38,7 @@ const postTestServer = setupServer(
               hits: 10,
               isAuthor: false,
               game: {
+                id: 1,
                 type: '농구',
                 date: '2022년 10월 20일 15:00~17:00',
                 place: '잠실실내체육관',
@@ -83,6 +85,7 @@ const postTestServer = setupServer(
           context.json({
             errorCode: 100,
             errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
+            gameId: null,
           }),
         );
       }
@@ -92,7 +95,8 @@ const postTestServer = setupServer(
           context.status(400),
           context.json({
             errorCode: 101,
-            errorMessage: '이미 신청이 완료된 운동입니다.',
+            errorMessage: '이미 신청 중이거나 신청이 완료된 운동입니다.',
+            gameId: null,
           }),
         );
       }
@@ -103,6 +107,18 @@ const postTestServer = setupServer(
           context.json({
             errorCode: 102,
             errorMessage: '주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다.',
+            gameId: null,
+          }),
+        );
+      }
+
+      if (gameId === '1' && accessToken === 'fully participated userId 3') {
+        return response(
+          context.status(400),
+          context.json({
+            errorCode: 103,
+            errorMessage: '참가 정원이 모두 차 참가를 신청할 수 없습니다.',
+            gameId: 1,
           }),
         );
       }


### PR DESCRIPTION
게시글의 게임에 신청하지 않은 사용자가 인원이 가득 찬 게시글 목록, 혹은 상세 내용을 확인할 경우
- 게시글 목록 조회 시
신청하기 버튼이 출력되지 않음
- 게시글 상세 내용 조회 시
신청하기 버튼이 '정원이 가득 찼습니다' 메세지로 바뀌어 출력되도록 함

다음의 상황에 대응하는 예외처리를 수행
- 사용자가 잔여석이 남은 게시글 목록이나 게시글 상세 내용을 조회해 신청하기 버튼이 있는 것을 확인
- 다른 사용자가 게시글에 참가를 신청하고, 작성자가 신청을 수락해 잔여석이 없게 만듦
- 사용자가 잔여석이 없게 된 해당 게시글에 신청하기 버튼 클릭 시 '정원이 모두 찼습니다.' 메세지를 띄움

<img width="716" alt="스크린샷 2022-11-27 오후 10 44 37" src="https://user-images.githubusercontent.com/50052512/204138636-5cccbaee-7423-4b68-bfc9-60ff71d3dc2b.png">

<img width="709" alt="스크린샷 2022-11-27 오후 10 45 46" src="https://user-images.githubusercontent.com/50052512/204138646-5e52431e-588f-4a3d-adae-e7c92b146517.png">
