### PR TITLE
게시글 목록 보기 기능에서 더 이상 참가신청을 수행할 수 없음

### DIFF
--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 import PostsContent from './PostsContent';
-import PostsRegisterButton from './PostsRegisterButton';
 import BackwardButton from './ui/BackwardButton';
 
 const Container = styled.article`
@@ -26,11 +25,7 @@ export default function Posts({
   posts,
   navigateToBackward,
   navigateToPost,
-  registerToGame,
-  cancelRegisterToGame,
-  cancelParticipateToGame,
   postsErrorMessage,
-  registerErrors,
 }) {
   const onClickBackward = () => {
     navigateToBackward();
@@ -72,25 +67,6 @@ export default function Posts({
               targetMemberCount={post.game.targetMemberCount}
               onClickPost={() => onClickPost(post.id)}
             />
-            {
-              post.isAuthor ? (
-                null
-              ) : (
-                <div>
-                  <PostsRegisterButton
-                    gameId={post.game.id}
-                    registerId={post.game.registerId}
-                    currentMemberCount={post.game.currentMemberCount}
-                    targetMemberCount={post.game.targetMemberCount}
-                    registerStatus={post.game.registerStatus}
-                    registerToGame={registerToGame}
-                    cancelRegisterToGame={cancelRegisterToGame}
-                    cancelParticipateToGame={cancelParticipateToGame}
-                    registerErrors={registerErrors}
-                  />
-                </div>
-              )
-            }
           </Thumbnail>
         ))}
       </Thumbnails>

--- a/src/components/Posts.test.jsx
+++ b/src/components/Posts.test.jsx
@@ -5,25 +5,17 @@ import Posts from './Posts';
 describe('Posts', () => {
   const navigateToBackward = jest.fn();
   const navigateToPost = jest.fn();
-  const registerToGame = jest.fn();
-  const cancelRegisterToGame = jest.fn();
-  const cancelParticipateToGame = jest.fn();
 
   const renderPosts = ({
     posts,
     postsErrorMessage,
-    registerErrors,
   }) => {
     render((
       <Posts
         posts={posts}
         navigateToBackward={navigateToBackward}
         navigateToPost={navigateToPost}
-        registerToGame={registerToGame}
-        cancelRegisterToGame={cancelRegisterToGame}
-        cancelParticipateToGame={cancelParticipateToGame}
         postsErrorMessage={postsErrorMessage}
-        registerErrors={registerErrors}
       />
     ));
   };
@@ -31,13 +23,11 @@ describe('Posts', () => {
   context('등록된 게시글이 존재하지 않는 경우', () => {
     const posts = [];
     const postsErrorMessage = '';
-    const registerErrors = {};
 
     it('게시물 미존재 안내 메세지 출력', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrors,
       });
 
       screen.getByText(/등록된 게시물이 존재하지 않습니다./);
@@ -47,13 +37,11 @@ describe('Posts', () => {
   context('게임이 찾아지지 않은 에러가 발생한 경우', () => {
     const posts = [];
     const postsErrorMessage = '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.';
-    const registerErrors = {};
 
     it('에러 메세지 출력', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrors,
       });
 
       screen.getByText(/주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다./);
@@ -79,13 +67,11 @@ describe('Posts', () => {
       },
     ];
     const postsErrorMessage = '';
-    const registerErrors = {};
 
     it('뒤로가기 버튼을 누를 시 뒤로가기로 이동하는 navigate 함수 호출', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrors,
       });
 
       fireEvent.click(screen.getByText('⬅️'));
@@ -96,62 +82,11 @@ describe('Posts', () => {
       renderPosts({
         posts,
         postsErrorMessage,
-        registerErrors,
       });
 
       fireEvent.click(screen.getByText('배드민턴'));
       const expectedPostId = 1;
       expect(navigateToPost).toBeCalledWith(expectedPostId);
-    });
-
-    it('사용자가 버튼을 클릭하고 나서 에러가 전달되었을 시 에러 메세지를 출력', () => {
-      const codeAndMessage = {
-        errorCode: 100,
-        errorMessage: '에러 메세지 내용입니다.',
-        gameId: 2,
-      };
-
-      renderPosts({
-        posts,
-        postsErrorMessage,
-        registerErrors: codeAndMessage,
-      });
-
-      screen.getByText(/에러 메세지 내용입니다./);
-    });
-  });
-
-  context('등록된 게시물이 있는데 작성자가 사용자 자신일 경우', () => {
-    const posts = [
-      {
-        id: 1,
-        hits: 334,
-        isAuthor: true,
-        game: {
-          id: 2,
-          type: '주짓수',
-          date: '2022년 10월 31일 08:00~11:00',
-          place: '팀 레드 주짓수&MMA',
-          currentMemberCount: 4,
-          targetMemberCount: 5,
-          registerId: 11,
-          registerStatus: 'accepted',
-        },
-      },
-    ];
-    const postsErrorMessage = '';
-    const registerErrors = {};
-
-    it('해당 게시글 리스트 제목 옆에 신청/취소/참가취소 버튼이 나타나지 않음', () => {
-      renderPosts({
-        posts,
-        postsErrorMessage,
-        registerErrors,
-      });
-
-      expect(screen.queryByText('신청')).toBeNull();
-      expect(screen.queryByText('신청취소')).toBeNull();
-      expect(screen.queryByText('참가취소')).toBeNull();
     });
   });
 });

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import { useLocalStorage } from 'usehooks-ts';
 
 import usePostStore from '../hooks/usePostStore';
-import useRegisterStore from '../hooks/useRegisterStore';
 
 import Posts from '../components/Posts';
 
@@ -14,14 +13,12 @@ export default function PostsPage() {
   const [accessToken] = useLocalStorage('accessToken', '');
 
   const postStore = usePostStore();
-  const registerStore = useRegisterStore();
 
   useEffect(() => {
     postStore.fetchPosts();
   }, [accessToken]);
 
   const { posts, postsErrorMessage } = postStore;
-  const { registerErrorCodeAndMessage } = registerStore;
 
   const navigateToBackward = () => {
     navigate(-1);
@@ -35,33 +32,12 @@ export default function PostsPage() {
     });
   };
 
-  const registerToGame = async (gameId) => {
-    const applicationId = await registerStore.registerToGame(gameId);
-    if (applicationId) {
-      await postStore.fetchPosts();
-    }
-  };
-
-  const cancelRegisterToGame = async (registerId) => {
-    await registerStore.cancelRegisterToGame(registerId);
-    await postStore.fetchPosts();
-  };
-
-  const cancelParticipateToGame = async (registerId) => {
-    await registerStore.cancelParticipateToGame(registerId);
-    await postStore.fetchPosts();
-  };
-
   return (
     <Posts
       posts={posts}
       navigateToBackward={navigateToBackward}
       navigateToPost={navigateToPost}
-      registerToGame={registerToGame}
-      cancelRegisterToGame={cancelRegisterToGame}
-      cancelParticipateToGame={cancelParticipateToGame}
       postsErrorMessage={postsErrorMessage}
-      registerErrors={registerErrorCodeAndMessage}
     />
   );
 }

--- a/src/pages/PostsPage.test.jsx
+++ b/src/pages/PostsPage.test.jsx
@@ -20,19 +20,6 @@ jest.mock('../hooks/usePostStore', () => () => ({
   fetchPosts,
 }));
 
-let registeredGameId;
-let registerErrorCodeAndMessage;
-let registerToGame;
-const cancelRegisterToGame = jest.fn();
-const cancelParticipateToGame = jest.fn();
-jest.mock('../hooks/useRegisterStore', () => () => ({
-  registeredGameId,
-  registerErrorCodeAndMessage,
-  registerToGame,
-  cancelRegisterToGame,
-  cancelParticipateToGame,
-}));
-
 describe('PostsPage', () => {
   function renderPostsPage() {
     render((
@@ -89,7 +76,6 @@ describe('PostsPage', () => {
           },
         },
       ];
-      registerErrorCodeAndMessage = {};
       postsErrorMessage = '';
     });
 
@@ -111,53 +97,6 @@ describe('PostsPage', () => {
             postId: 2,
           },
         });
-      });
-    });
-
-    context('운동 신청 버튼을 누르면', () => {
-      const expectedGameId = 22;
-      registeredGameId = expectedGameId;
-
-      it('운동 신청을 위한 registerToGame 호출 후'
-        + '운동 모집 게시글 상태 최신화를 위해 fetchPosts 다시 호출', async () => {
-        jest.clearAllMocks();
-        registerToGame = jest.fn(() => registeredGameId);
-
-        renderPostsPage();
-
-        fireEvent.click(screen.getByText('신청'));
-        await expect(registerToGame).toBeCalledWith(expectedGameId);
-        await expect(fetchPosts).toBeCalledTimes(2);
-      });
-    });
-
-    context('운동 신청 취소 버튼을 누르면', () => {
-      const expectedRegisterId = 25;
-
-      it('운동 신청 취소를 위한 cancelRegisterToGame 호출 후'
-        + '운동 모집 게시글 상태 최신화를 위해 fetchPosts 다시 호출', async () => {
-        jest.clearAllMocks();
-
-        renderPostsPage();
-
-        fireEvent.click(screen.getByText('신청취소'));
-        await expect(cancelRegisterToGame).toBeCalledWith(expectedRegisterId);
-        await expect(fetchPosts).toBeCalledTimes(2);
-      });
-    });
-
-    context('운동 참가 취소 버튼을 누르면', () => {
-      const expectedRegisterId = 40;
-
-      it('운동 참가 취소를 위한 cancelParticipateToGame 호출 후'
-        + '운동 모집 게시글 상태 최신화를 위해 fetchPosts 다시 호출', async () => {
-        jest.clearAllMocks();
-
-        renderPostsPage();
-
-        fireEvent.click(screen.getByText('참가취소'));
-        await expect(cancelParticipateToGame).toBeCalledWith(expectedRegisterId);
-        await expect(fetchPosts).toBeCalledTimes(2);
       });
     });
   });


### PR DESCRIPTION
UX와 신청 기능의 중요성을 고려할 때 목록을 조회하면서 바로 신청하는 것이 적합하지 않다고 판단됨

- UI 컴포넌트에서 신청 버튼 삭제
- 페이지 컴포넌트에서 RegisterStore에 더 이상 접근하지 않음
- 관련된 테스트 코드 삭제

얘상 뽀모 1
실제 뽀모 0.5

회고
버튼 삭제는 버튼 컴포넌트를 지우고, 페이지 컴포넌트에서 RegisterStore를 참조하지 않게 하는 것으로 굉장히 간단하게 끝났음
대신 이제는 내가 참가하는/모집하는 운동만을 골라 보여줘야 할 필요성이 생기게 되었음
메인 화면을 옮기는 작업을 할 때, 새로 작성한 UI를 보면서 컴포넌트를 추가하고 기능을 추가하는 작업을 추가로 설계해야 하겠음