### PR TITLE
React-Modal 라이브러리 의존성 추가, 기능 버튼 클릭 시 Modal을 이용해 재확인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "react-datepicker": "^4.8.0",
                 "react-dom": "^18.2.0",
                 "react-hook-form": "^7.39.5",
+                "react-modal": "^3.16.1",
                 "react-router-dom": "^6.4.2",
                 "styled-components": "^5.3.6",
                 "styled-reset": "^4.4.2",
@@ -6949,6 +6950,11 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
+        "node_modules/exenv": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+            "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+        },
         "node_modules/exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -12882,6 +12888,29 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-lifecycles-compat": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
+        "node_modules/react-modal": {
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+            "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.7.2",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+            }
         },
         "node_modules/react-onclickoutside": {
             "version": "6.12.2",
@@ -20264,6 +20293,11 @@
                 "strip-final-newline": "^2.0.0"
             }
         },
+        "exenv": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+            "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+        },
         "exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -24737,6 +24771,22 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-lifecycles-compat": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
+        "react-modal": {
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+            "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+            "requires": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.7.2",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^4.0.3"
+            }
         },
         "react-onclickoutside": {
             "version": "6.12.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "react-datepicker": "^4.8.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.39.5",
+        "react-modal": "^3.16.1",
         "react-router-dom": "^6.4.2",
         "styled-components": "^5.3.6",
         "styled-reset": "^4.4.2",

--- a/src/components/ModalConfirm.jsx
+++ b/src/components/ModalConfirm.jsx
@@ -1,0 +1,51 @@
+import ReactModal from 'react-modal';
+
+const modalStyle = {
+  overlay: {
+    backgroundColor: '#000000bb',
+  },
+  content: {
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    fontSize: '1.5em',
+    height: '12em',
+    width: '20em',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: '1em',
+  },
+};
+
+export default function ModalConfirm({
+  actionMessage,
+  confirmModalState,
+  setConfirmModalState,
+}) {
+  const handleCloseModal = () => {
+    setConfirmModalState(false);
+  };
+
+  return (
+    <ReactModal
+      isOpen={confirmModalState}
+      onRequestClose={handleCloseModal}
+      style={modalStyle}
+    >
+      <p>
+        {actionMessage}
+        {' '}
+        완료되었습니다.
+      </p>
+      <button
+        type="button"
+        onClick={handleCloseModal}
+      >
+        확인
+      </button>
+    </ReactModal>
+  );
+}

--- a/src/components/ModalReconfirm.jsx
+++ b/src/components/ModalReconfirm.jsx
@@ -1,0 +1,63 @@
+import ReactModal from 'react-modal';
+
+const modalStyle = {
+  overlay: {
+    backgroundColor: '#000000bb',
+  },
+  content: {
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    fontSize: '1.5em',
+    height: '12em',
+    width: '20em',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: '1em',
+  },
+};
+
+export default function ModalReconfirm({
+  action,
+  actionMessage,
+  reconfirmModalState,
+  setReconfirmModalState,
+}) {
+  const handleClickProgress = async () => {
+    await action();
+  };
+
+  const handleCloseModal = () => {
+    setReconfirmModalState(false);
+  };
+
+  return (
+    <ReactModal
+      isOpen={reconfirmModalState}
+      onRequestClose={handleCloseModal}
+      style={modalStyle}
+    >
+      <p>
+        정말로
+        {' '}
+        {actionMessage}
+        하시겠습니까?
+      </p>
+      <button
+        type="button"
+        onClick={handleClickProgress}
+      >
+        예
+      </button>
+      <button
+        type="button"
+        onClick={handleCloseModal}
+      >
+        아니오
+      </button>
+    </ReactModal>
+  );
+}

--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -51,12 +51,12 @@ export default function Post({
   game,
   members,
   applicants,
-  handleClickDeletePost,
+  reconfirmDeletePost,
   handleClickRegister,
-  handleClickRegisterCancel,
-  handleClickParticipateCancel,
-  acceptRegister,
-  rejectRegister,
+  reconfirmRegisterCancel,
+  reconfirmParticipateCancel,
+  handleClickAcceptRegister,
+  reconfirmRegisterReject,
   registerError,
 }) {
   const onClickBackward = () => {
@@ -72,7 +72,7 @@ export default function Post({
   };
 
   const onClickDeletePost = () => {
-    handleClickDeletePost(post.id);
+    reconfirmDeletePost(post.id);
   };
 
   const onClickRegister = () => {
@@ -80,11 +80,19 @@ export default function Post({
   };
 
   const onClickRegisterCancel = () => {
-    handleClickRegisterCancel(game.registerId);
+    reconfirmRegisterCancel(game.registerId);
   };
 
   const onClickParticipateCancel = () => {
-    handleClickParticipateCancel(game.registerId);
+    reconfirmParticipateCancel(game.registerId);
+  };
+
+  const onClickAcceptRegister = (registerId) => {
+    handleClickAcceptRegister(registerId);
+  };
+
+  const onClickRejectRegister = (registerId) => {
+    reconfirmRegisterReject(registerId);
   };
 
   if (!post || !game || !members
@@ -141,8 +149,8 @@ export default function Post({
               cannotAcceptRegister={(
                 game.currentMemberCount >= game.targetMemberCount
               )}
-              acceptRegister={acceptRegister}
-              rejectRegister={rejectRegister}
+              onClickAcceptRegister={onClickAcceptRegister}
+              onClickRejectRegister={onClickRejectRegister}
             />
           ) : (
             game.registerStatus === 'processing' || game.registerStatus === 'accepted' ? (
@@ -172,7 +180,7 @@ export default function Post({
             <p>참가 정원이 모두 찼습니다.</p>
           ) : (
             <LoginGuidance>
-              <p>운동에 신청하려면 로그인해주세요.</p>
+              <p>운동에 참가를 신청하려면 로그인해주세요.</p>
               <button
                 type="button"
                 onClick={onClickLogin}

--- a/src/components/PostForm.jsx
+++ b/src/components/PostForm.jsx
@@ -22,7 +22,7 @@ const SubmitButton = styled.button`
 
 export default function PostForm({
   data,
-  navigateToBackward,
+  reconfirmNavigateBackward,
   changeGameExercise,
   changeGameDate,
   changeGameStartTimeAmPm,
@@ -39,7 +39,7 @@ export default function PostForm({
   serverErrors,
 }) {
   const handleClickBackward = () => {
-    navigateToBackward();
+    reconfirmNavigateBackward();
   };
 
   const handleChangeGameExercise = (event) => {

--- a/src/components/PostGameApplicantsInformation.jsx
+++ b/src/components/PostGameApplicantsInformation.jsx
@@ -39,15 +39,15 @@ const Buttons = styled.div`
 export default function PostGameApplicantsInformation({
   applicants,
   cannotAcceptRegister,
-  acceptRegister,
-  rejectRegister,
+  onClickAcceptRegister,
+  onClickRejectRegister,
 }) {
   const handleClickAcceptRegister = (applicantId) => {
-    acceptRegister(applicantId);
+    onClickAcceptRegister(applicantId);
   };
 
   const handleClickRejectRegister = (applicantId) => {
-    rejectRegister(applicantId);
+    onClickRejectRegister(applicantId);
   };
 
   if (!applicants) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import ReactModal from 'react-modal';
 import App from './App';
 import { postApiService } from './services/PostApiService';
 import { gameApiService } from './services/GameApiService';
@@ -10,6 +11,8 @@ const accessToken = JSON.parse(data);
 postApiService.setAccessToken(accessToken);
 gameApiService.setAccessToken(accessToken);
 registerApiService.setAccessToken(accessToken);
+
+ReactModal.setAppElement('#app');
 
 const container = document.getElementById('app');
 const root = ReactDOM.createRoot(container);

--- a/src/pages/PostFormPage.jsx
+++ b/src/pages/PostFormPage.jsx
@@ -1,9 +1,13 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import ModalReconfirm from '../components/ModalReconfirm';
 import PostForm from '../components/PostForm';
 import usePostFormStore from '../hooks/usePostFormStore';
 
 export default function PostFormPage() {
+  const [actionMessage, setActionMessage] = useState('');
+  const [reconfirmModalState, setReconfirmModalState] = useState(false);
+
   const navigate = useNavigate();
 
   const postFormStore = usePostFormStore();
@@ -38,9 +42,22 @@ export default function PostFormPage() {
     postDetail,
   };
 
-  const navigateToBackward = () => {
+  const seeReconfirmModal = ({ message }) => {
+    setActionMessage(message);
+    setReconfirmModalState(true);
+  };
+
+  const reconfirmNavigateBackward = () => {
+    seeReconfirmModal({ message: '게시글 작성을 중단' });
+  };
+
+  const navigateBackward = () => {
     postFormStore.clearStates();
-    navigate(-1);
+    navigate(-1, {
+      state: {
+        postStatus: '',
+      },
+    });
   };
 
   const changeGameExercise = (exercise) => {
@@ -91,28 +108,42 @@ export default function PostFormPage() {
     const postId = await postFormStore.createPost();
     if (postId) {
       postFormStore.clearStates();
-      navigate('/posts/list');
+      navigate('/posts/list', {
+        state: {
+          postStatus: 'created',
+        },
+      });
     }
   };
 
   return (
-    <PostForm
-      data={data}
-      navigateToBackward={navigateToBackward}
-      changeGameExercise={changeGameExercise}
-      changeGameDate={changeGameDate}
-      changeGameStartTimeAmPm={changeGameStartTimeAmPm}
-      changeGameStartHour={changeGameStartHour}
-      changeGameStartMinute={changeGameStartMinute}
-      changeGameEndTimeAmPm={changeGameEndTimeAmPm}
-      changeGameEndHour={changeGameEndHour}
-      changeGameEndMinute={changeGameEndMinute}
-      changeGamePlace={changeGamePlace}
-      changeGameTargetMemberCount={changeGameTargetMemberCount}
-      changePostDetail={changePostDetail}
-      createPost={createPost}
-      formErrors={formErrors}
-      serverErrors={serverErrors}
-    />
+    <>
+      <PostForm
+        data={data}
+        reconfirmNavigateBackward={reconfirmNavigateBackward}
+        changeGameExercise={changeGameExercise}
+        changeGameDate={changeGameDate}
+        changeGameStartTimeAmPm={changeGameStartTimeAmPm}
+        changeGameStartHour={changeGameStartHour}
+        changeGameStartMinute={changeGameStartMinute}
+        changeGameEndTimeAmPm={changeGameEndTimeAmPm}
+        changeGameEndHour={changeGameEndHour}
+        changeGameEndMinute={changeGameEndMinute}
+        changeGamePlace={changeGamePlace}
+        changeGameTargetMemberCount={changeGameTargetMemberCount}
+        changePostDetail={changePostDetail}
+        createPost={createPost}
+        formErrors={formErrors}
+        serverErrors={serverErrors}
+      />
+      {reconfirmModalState && (
+        <ModalReconfirm
+          action={navigateBackward}
+          actionMessage={actionMessage}
+          reconfirmModalState={reconfirmModalState}
+          setReconfirmModalState={setReconfirmModalState}
+        />
+      )}
+    </>
   );
 }

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,14 +1,24 @@
-import { useEffect } from 'react';
+/* eslint-disable no-nested-ternary */
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useLocalStorage } from 'usehooks-ts';
 import Post from '../components/Post';
 import usePostStore from '../hooks/usePostStore';
 import useGameStore from '../hooks/useGameStore';
 import useRegisterStore from '../hooks/useRegisterStore';
+import ModalConfirm from '../components/ModalConfirm';
+import ModalReconfirm from '../components/ModalReconfirm';
 
 export default function PostPage() {
   const [accessToken] = useLocalStorage('accessToken', '');
   const loggedIn = accessToken !== '';
+
+  const [registerId, setRegisterId] = useState(0);
+  const [postIdToBeDeleted, setPostIdToBeDeleted] = useState(0);
+  const [actionName, setActionName] = useState('');
+  const [actionMessage, setActionMessage] = useState('');
+  const [confirmModalState, setConfirmModalState] = useState(false);
+  const [reconfirmModalState, setReconfirmModalState] = useState(false);
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -60,55 +70,127 @@ export default function PostPage() {
     navigate('/login');
   };
 
-  const handleClickDeletePost = async (targetPostId) => {
-    await postStore.deletePost(targetPostId);
-    navigate('/posts/list');
+  const seeConfirmModal = ({ message }) => {
+    setActionMessage(message);
+    setConfirmModalState(true);
+  };
+
+  const seeReconfirmModal = ({ action, message }) => {
+    setActionName(action);
+    setActionMessage(message);
+    setReconfirmModalState(true);
+  };
+
+  const hideReconfirmModal = () => {
+    setActionName('');
+    setReconfirmModalState(false);
+  };
+
+  const reconfirmDeletePost = (targetPostId) => {
+    setPostIdToBeDeleted(targetPostId);
+    seeReconfirmModal({ action: 'deletePost', message: '게시글을 삭제' });
+  };
+
+  const deletePost = async () => {
+    await postStore.deletePost(postIdToBeDeleted);
+    navigate('/posts/list', {
+      state: {
+        postStatus: 'deleted',
+      },
+    });
   };
 
   const handleClickRegister = async (gameId) => {
     const applicationId = await registerStore.registerToGame(gameId);
     if (applicationId) {
       await fetchData(postId);
+      seeConfirmModal({ message: '참가 신청이' });
     }
   };
 
-  const handleClickRegisterCancel = async (registerId) => {
+  const reconfirmRegisterCancel = (targetRegisterId) => {
+    setRegisterId(targetRegisterId);
+    seeReconfirmModal({ action: 'registerCancel', message: '참가 신청을 취소' });
+  };
+
+  const reconfirmParticipateCancel = (targetRegisterId) => {
+    setRegisterId(targetRegisterId);
+    seeReconfirmModal({ action: 'participateCancel', message: '참가를 취소' });
+  };
+
+  const reconfirmRegisterReject = (targetRegisterId) => {
+    setRegisterId(targetRegisterId);
+    seeReconfirmModal({ action: 'registerReject', message: '참가 신청을 거절' });
+  };
+
+  const cancelRegister = async () => {
     await registerStore.cancelRegisterToGame(registerId);
     await fetchData(postId);
+    hideReconfirmModal();
+    seeConfirmModal({ message: '참가 신청 취소가' });
   };
 
-  const handleClickParticipateCancel = async (registerId) => {
+  const cancelParticipate = async () => {
     await registerStore.cancelParticipateToGame(registerId);
     await fetchData(postId);
+    hideReconfirmModal();
+    seeConfirmModal({ message: '참가 취소가' });
   };
 
-  const acceptRegister = async (registerId) => {
-    await registerStore.acceptRegister(registerId);
+  const handleClickAcceptRegister = async (targetRegisterId) => {
+    await registerStore.acceptRegister(targetRegisterId);
     await fetchData(postId);
+    seeConfirmModal({ message: '참가 신청 수락이' });
   };
 
-  const rejectRegister = async (registerId) => {
+  const rejectRegister = async () => {
     await registerStore.rejectRegister(registerId);
     await fetchData(postId);
+    hideReconfirmModal();
+    seeConfirmModal({ message: '참가 신청 거절이' });
   };
 
   return (
-    <Post
-      loggedIn={loggedIn}
-      navigateToBackward={navigateToBackward}
-      navigateToLogin={navigateToLogin}
-      navigateToSelectTrialAccount={navigateToSelectTrialAccount}
-      post={post}
-      game={game}
-      members={members}
-      applicants={applicants}
-      handleClickDeletePost={handleClickDeletePost}
-      handleClickRegister={handleClickRegister}
-      handleClickRegisterCancel={handleClickRegisterCancel}
-      handleClickParticipateCancel={handleClickParticipateCancel}
-      acceptRegister={acceptRegister}
-      rejectRegister={rejectRegister}
-      registerError={registerErrorCodeAndMessage}
-    />
+    <>
+      <Post
+        loggedIn={loggedIn}
+        navigateToBackward={navigateToBackward}
+        navigateToLogin={navigateToLogin}
+        navigateToSelectTrialAccount={navigateToSelectTrialAccount}
+        post={post}
+        game={game}
+        members={members}
+        applicants={applicants}
+        reconfirmDeletePost={reconfirmDeletePost}
+        handleClickRegister={handleClickRegister}
+        reconfirmRegisterCancel={reconfirmRegisterCancel}
+        reconfirmParticipateCancel={reconfirmParticipateCancel}
+        handleClickAcceptRegister={handleClickAcceptRegister}
+        reconfirmRegisterReject={reconfirmRegisterReject}
+        registerError={registerErrorCodeAndMessage}
+      />
+      {confirmModalState && (
+        <ModalConfirm
+          actionMessage={actionMessage}
+          confirmModalState={confirmModalState}
+          setConfirmModalState={setConfirmModalState}
+        />
+      )}
+      {reconfirmModalState && (
+        <ModalReconfirm
+          action={(
+            actionName === 'registerCancel' ? cancelRegister
+              : actionName === 'participateCancel' ? cancelParticipate
+                : actionName === 'registerReject' ? rejectRegister
+                  : actionName === 'deletePost' ? deletePost
+                    : null
+          )}
+          actionMessage={actionMessage}
+          reconfirmModalState={reconfirmModalState}
+          setReconfirmModalState={setReconfirmModalState}
+        />
+      )}
+    </>
+
   );
 }

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useLocalStorage } from 'usehooks-ts';
 
@@ -7,9 +7,18 @@ import usePostStore from '../hooks/usePostStore';
 
 import Posts from '../components/Posts';
 import { postApiService } from '../services/PostApiService';
+import ModalConfirm from '../components/ModalConfirm';
 
 export default function PostsPage() {
+  const [actionMessage, setActionMessage] = useState('');
+  const [confirmModalState, setConfirmModalState] = useState(false);
+
+  const location = useLocation();
   const navigate = useNavigate();
+
+  const postStatus = !location.state
+    ? null
+    : location.state.postStatus;
 
   const [accessToken] = useLocalStorage('accessToken', '');
   const loggedIn = accessToken !== '';
@@ -19,7 +28,19 @@ export default function PostsPage() {
 
   const postStore = usePostStore();
 
+  const seeConfirmModal = ({ message }) => {
+    setActionMessage(message);
+    setConfirmModalState(true);
+  };
+
   useEffect(() => {
+    if (postStatus) {
+      seeConfirmModal({
+        message: postStatus === 'created'
+          ? '게시글 작성이'
+          : '게시글 삭제가',
+      });
+    }
     postApiService.setAccessToken(accessToken);
     postStore.fetchPosts();
   }, [accessToken]);
@@ -48,15 +69,24 @@ export default function PostsPage() {
   };
 
   return (
-    <Posts
-      loggedIn={loggedIn}
-      searchSetting={searchSetting}
-      filterSetting={filterSetting}
-      toggleSearchSetting={handleClickToggleSearchSetting}
-      toggleFilterSetting={handleClickToggleFilterSetting}
-      posts={posts}
-      navigateToPost={navigateToPost}
-      postsErrorMessage={postsErrorMessage}
-    />
+    <>
+      <Posts
+        loggedIn={loggedIn}
+        searchSetting={searchSetting}
+        filterSetting={filterSetting}
+        toggleSearchSetting={handleClickToggleSearchSetting}
+        toggleFilterSetting={handleClickToggleFilterSetting}
+        posts={posts}
+        navigateToPost={navigateToPost}
+        postsErrorMessage={postsErrorMessage}
+      />
+      {confirmModalState && (
+        <ModalConfirm
+          actionMessage={actionMessage}
+          confirmModalState={confirmModalState}
+          setConfirmModalState={setConfirmModalState}
+        />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
Modal 창은 등록하기 관련 동작, 취소하기 관련 동작에서 작동

등록하기 관련 동작
- 종류
  - 신청, 신청 수락, 글 작성
- 신청, 신청 수락은 같은 화면에서 Modal 창을 띄우고, 확인 버튼 클릭 시 사라짐
- 글 작성 버튼은 화면 이동 전에 띄우기 (화면이 넘어가도 조작할 수 있으려나?)
- 목적: Confirm
  - 단순히 확인만 시켜주고, 확인 버튼을 누르거나 키보드의 esc, 화면 바깥을 클릭해 나가는 구조

취소/거절 관련 동작
- 종류
  - 신청취소, 참가취소, 신청 거절, 글 작성 도중 뒤로 navigate, 글 삭제
- 목적: DoubleCheck
  - 정말로 취소/거절/중단 등 하시겠습니까? 질문
  - '네' 를 눌러야 handleClick 실행
  - '아니오'를 누르면 Modal을 빠져나가고 아무것도 하지 않음

react-modal: App element is not defined. Please use `Modal.setAppElement(el)` or set `appElement={el}`. This is needed so screen readers don't see main content when modal is opened. It is not recommended, but you can opt-out by setting `ariaHideApp={false}` 에러 메시지가 출력되는 이슈가 있어 index.jsx에 ReactModal.setAppElement('#app');을 추가

취소 관련 동작 시, 재확인 시 '예' 버튼을 누를 경우의 동작의 구현은 Page 컴포넌트에서 useState로 실행핢 메서드의 이름을 들고 있고, 재확인 modal을 출력시킬 때 useState가 들고 있는 실행할 메서드의 이름에 따라 실행 함수를 전달하는 식으로 구현

<img width="642" alt="스크린샷 2022-12-02 오후 11 53 03" src="https://user-images.githubusercontent.com/50052512/205320560-3644c8b3-1dfd-4f4d-b06a-d257da857624.png">


예상 뽀모 5
실제 뽀모 12

회고
사실상 작업을 다음의 2개로 나눠야 했음
- Modal 라이브러리 사용방법 학습 및 의존성 추가
- 각 기능 동작 시 확인 용도로 Modal 출력