### PR TITLE
게시글 작성, 삭제 후 이동한 다른 페이지에서 뒤로 가기 시 Modal 출력 오류 수정

### DIFF
--- a/src/components/BottomNavigator.jsx
+++ b/src/components/BottomNavigator.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Container = styled.nav`
@@ -14,10 +14,15 @@ const Container = styled.nav`
 `;
 
 export default function BottomNavigator() {
+  const location = useLocation();
   const navigate = useNavigate();
 
   const handleClickButton = (link) => {
-    navigate(link);
+    navigate(link, {
+      state: {
+        previousPath: location.pathname,
+      },
+    });
   };
 
   return (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useLocalStorage } from 'usehooks-ts';
 import useUserStore from '../hooks/useUserStore';
@@ -33,6 +33,7 @@ const Side = styled.nav`
 `;
 
 export default function Header() {
+  const location = useLocation();
   const navigate = useNavigate();
 
   const [accessToken, setAccessToken] = useLocalStorage('accessToken', '');
@@ -49,7 +50,11 @@ export default function Header() {
   const { name } = userStore;
 
   const navigateNoticesPage = () => {
-    navigate('/notices');
+    navigate('/notices', {
+      state: {
+        previousPath: location.pathname,
+      },
+    });
   };
 
   const handleClickLogout = () => {
@@ -58,7 +63,11 @@ export default function Header() {
   };
 
   const navigateLoginPage = () => {
-    navigate('/login');
+    navigate('/login', {
+      state: {
+        previousPath: location.pathname,
+      },
+    });
   };
 
   return (

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
 import styled from 'styled-components';
+import BackwardButton from './ui/BackwardButton';
 
 const Container = styled.article`
   padding-block: 30px;
@@ -28,6 +29,7 @@ const Button = styled.button`
 `;
 
 export default function LoginForm({
+  onClickBackward,
   register,
   handleSubmit,
   login,
@@ -38,6 +40,12 @@ export default function LoginForm({
 
   return (
     <Container>
+      <BackwardButton
+        type="button"
+        onClick={onClickBackward}
+      >
+        ⬅️
+      </BackwardButton>
       <Form onSubmit={handleSubmit(submit)}>
         <div>
           <label htmlFor="input-username">

--- a/src/components/PostForm.jsx
+++ b/src/components/PostForm.jsx
@@ -36,7 +36,7 @@ export default function PostForm({
   changePostDetail,
   createPost,
   formErrors,
-  serverErrors,
+  serverError,
 }) {
   const handleClickBackward = () => {
     reconfirmNavigateBackward();
@@ -293,8 +293,8 @@ export default function PostForm({
           작성하기
         </SubmitButton>
       </Form>
-      {serverErrors.errorMessages ? (
-        <p>{serverErrors.errorMessages}</p>
+      {serverError ? (
+        <p>{serverError}</p>
       ) : null}
     </Container>
   );

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,13 +1,18 @@
 import { useForm } from 'react-hook-form';
 import { useLocalStorage } from 'usehooks-ts';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import useUserStore from '../hooks/useUserStore';
 import LoginForm from '../components/LoginForm';
 import LoginErrors from '../components/LoginErrors';
 
 export default function LoginPage() {
+  const location = useLocation();
   const navigate = useNavigate();
+
+  const previousPath = location.state !== null
+    ? location.state.previousPath
+    : null;
 
   const [, setAccessToken] = useLocalStorage('accessToken', '');
 
@@ -17,6 +22,10 @@ export default function LoginPage() {
     userStore.clearLoginError();
   }, []);
 
+  const navigateBackward = () => {
+    navigate(previousPath || '/');
+  };
+
   const { register, handleSubmit, formState: { errors } } = useForm({ reValidateMode: 'onSubmit' });
 
   const login = async (data) => {
@@ -24,7 +33,7 @@ export default function LoginPage() {
     const verifiedAccessToken = await userStore.login({ username, password });
     if (verifiedAccessToken) {
       setAccessToken(verifiedAccessToken);
-      navigate('/');
+      navigate(-1);
     }
   };
 
@@ -33,11 +42,10 @@ export default function LoginPage() {
   return (
     <>
       <LoginForm
+        onClickBackward={navigateBackward}
         register={register}
         handleSubmit={handleSubmit}
         login={login}
-        loginFormError={errors}
-        loginProcessError={loginErrorMessage}
       />
       <LoginErrors
         loginFormError={errors}

--- a/src/pages/NoticesPage.jsx
+++ b/src/pages/NoticesPage.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-nested-ternary */
+
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useLocalStorage } from 'usehooks-ts';
 
 import useNoticeStore from '../hooks/useNoticeStore';
@@ -11,10 +12,15 @@ export default function NoticesPage() {
   const [accessToken] = useLocalStorage('accessToken', '');
   const loggedIn = accessToken !== '';
 
+  const location = useLocation();
   const navigate = useNavigate();
 
+  const previousPath = location.state !== null
+    ? location.state.previousPath
+    : null;
+
   const navigateBackward = () => {
-    navigate(-1);
+    navigate(previousPath || '/');
   };
 
   const navigateLogin = () => {

--- a/src/pages/PostFormPage.jsx
+++ b/src/pages/PostFormPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import ModalReconfirm from '../components/ModalReconfirm';
 import PostForm from '../components/PostForm';
 import usePostFormStore from '../hooks/usePostFormStore';
@@ -8,7 +8,12 @@ export default function PostFormPage() {
   const [actionMessage, setActionMessage] = useState('');
   const [reconfirmModalState, setReconfirmModalState] = useState(false);
 
+  const location = useLocation();
   const navigate = useNavigate();
+
+  const previousPath = location.state !== null
+    ? location.state.previousPath
+    : null;
 
   const postFormStore = usePostFormStore();
 
@@ -27,7 +32,7 @@ export default function PostFormPage() {
     gameTargetMemberCount,
     postDetail,
     formErrors,
-    serverErrors,
+    serverError,
   } = postFormStore;
 
   const data = {
@@ -53,11 +58,7 @@ export default function PostFormPage() {
 
   const navigateBackward = () => {
     postFormStore.clearStates();
-    navigate(-1, {
-      state: {
-        postStatus: '',
-      },
-    });
+    navigate(previousPath || '/');
   };
 
   const changeGameExercise = (exercise) => {
@@ -134,7 +135,7 @@ export default function PostFormPage() {
         changePostDetail={changePostDetail}
         createPost={createPost}
         formErrors={formErrors}
-        serverErrors={serverErrors}
+        serverError={serverError}
       />
       {reconfirmModalState && (
         <ModalReconfirm

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-nested-ternary */
+
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useLocalStorage } from 'usehooks-ts';
@@ -56,8 +57,8 @@ export default function PostPage() {
     registerErrorCodeAndMessage,
   } = registerStore;
 
-  const navigateToBackward = () => {
-    navigate(-1);
+  const navigateBackward = () => {
+    navigate('/posts/list');
   };
 
   const navigateToLogin = () => {
@@ -154,7 +155,7 @@ export default function PostPage() {
     <>
       <Post
         loggedIn={loggedIn}
-        navigateToBackward={navigateToBackward}
+        navigateBackward={navigateBackward}
         navigateToLogin={navigateToLogin}
         navigateToSelectTrialAccount={navigateToSelectTrialAccount}
         post={post}

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -60,7 +60,7 @@ export default function PostsPage() {
     toggleFilterSetting(!filterSetting);
   };
 
-  const navigateToPost = (postId) => {
+  const navigatePost = (postId) => {
     navigate(`/posts/${postId}`, {
       state: {
         postId,
@@ -77,7 +77,7 @@ export default function PostsPage() {
         toggleSearchSetting={handleClickToggleSearchSetting}
         toggleFilterSetting={handleClickToggleFilterSetting}
         posts={posts}
-        navigateToPost={navigateToPost}
+        navigatePost={navigatePost}
         postsErrorMessage={postsErrorMessage}
       />
       {confirmModalState && (

--- a/src/stores/PostFormStore.js
+++ b/src/stores/PostFormStore.js
@@ -35,7 +35,7 @@ export default class PostFormStore extends Store {
     };
     this.hasFormErrors = false;
 
-    this.serverErrors = {};
+    this.serverError = '';
   }
 
   changeGameExercise(exercise) {
@@ -174,8 +174,8 @@ export default class PostFormStore extends Store {
       });
       return data.postId;
     } catch (error) {
-      const { errorMessages } = error.response.data;
-      this.serverErrors = errorMessages;
+      const { message } = error.response.data;
+      this.serverError = message;
       this.publish();
       return '';
     }
@@ -212,7 +212,7 @@ export default class PostFormStore extends Store {
     this.postDetail = '';
     this.clearFormErrors();
 
-    this.serverErrors = {};
+    this.serverError = '';
 
     this.publish();
   }


### PR DESCRIPTION
각 페이지 별로 뒤로가기 버튼 클릭 시 navigate(-1)을 하게 할 것인지, navigate(주소)를 하게 할 것인지 결정

처음에는 navigate(-1)을 유지하는 것을 계획
헤더나 하단 네비게이터에서 접근할 수 있는 기능들은 어느 화면에서든 해당 기능에 접근할 수 있기 때문에, 이전 화면으로 돌아갈 수 있어야 했음
  
Modal을 추가한 이후, 게시글 작성, 삭제 같은 페이지 이동 후 출력되는 Modal이 다른 페이지에서 navigate(-1)을 했을 때 해당 Modal을 출력시키는 오류가 발생
- 게시물 작성을 완료하거나, 삭제를 완료할 때 목록 보기 화면으로 이동하면서 postStatus 값을 주는데, 목록 보기 화면에서 -1로 빠져나올 수 있는 페이지로 갔다가 그 페이지에서 -1로 돌아가면 stack에 쌓여 있던 이전 페이지에서는 postStatus 값이 계속 살아있어서 게시물 작성을 완료하거나 삭제한 상태가 아닌데도 Modal 창이 출력되고 있는 것 같음
- 먼저 각 페이지에서 navigate(-1)을 할 때마다 state로 빈 값의 postStatus를 주는 것을 시도해보았지만 실패, 그리고 생각해보면 postStatus에 관심 없는 페이지에서 postStatus를 주면서 navigate를 하는 건 이상함
- 이번에는 postStatus가 아닌 아예 빈 state를 주면 어떻게 될지 한번 시도해보았지만 실패
- state의 속성으로 replace: true를 줘도 실패
- navigate(-1) 자체가 이전 stack 값을 가져오는??? 것이기 때문에 한계가 있는 것 같다.
  
'-1'을 쓰지 않고도 직전 페이지 주소로 뒤로가기를 할 수 있는 방법이 있을까?
- navigate를 할 때, 현재 페이지를 state로 같이 넘긴다면, 받아온 state에 들어 있는 이전 페이지 주소를 기억하고 있다가 뒤로가기 navigate를 할 때 그 주소로 가게 하는 방법이 있을 것 같다.
- 이전 페이지에서 navigate를 해올 때 state로 'prevPath: location.pathname'을 부여
- 주소로 직접 접근하는 경우에는 previousPath가 없으므로 홈으로 가도록 했음
- https://thewebdev.info/2022/03/08/how-to-detect-previous-path-in-react-router/

예상 뽀모 2
실제 뽀모 2.5
