### PR TITLE
로그인하지 않고 글 작성 페이지 접근 시도 시 로그인 안내 Modal 출력

### DIFF
--- a/src/components/BottomNavigator.jsx
+++ b/src/components/BottomNavigator.jsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { useLocalStorage } from 'usehooks-ts';
+import ModalLoginGuide from './ModalLoginGuide';
 
 const Container = styled.nav`
   position: fixed;
@@ -14,11 +17,40 @@ const Container = styled.nav`
 `;
 
 export default function BottomNavigator() {
+  const [accessToken] = useLocalStorage('accessToken', '');
+
   const location = useLocation();
   const navigate = useNavigate();
 
-  const handleClickButton = (link) => {
-    navigate(link, {
+  const [loginGuideModalState, setLoginGuideModalState] = useState(false);
+
+  const navigateHome = () => {
+    navigate('/');
+  };
+
+  const navigatePage = (link) => {
+    if (accessToken) {
+      navigate(link, {
+        state: {
+          previousPath: location.pathname,
+        },
+      });
+      return;
+    }
+
+    setLoginGuideModalState(true);
+  };
+
+  const navigateLogin = () => {
+    navigate('/login', {
+      state: {
+        previousPath: location.pathname,
+      },
+    });
+  };
+
+  const navigateSelectTrialAccount = () => {
+    navigate('/trial-account', {
       state: {
         previousPath: location.pathname,
       },
@@ -26,25 +58,33 @@ export default function BottomNavigator() {
   };
 
   return (
-    <Container>
-      <button
-        type="button"
-        onClick={() => handleClickButton('/')}
-      >
-        홈
-      </button>
-      <button
-        type="button"
-        onClick={() => handleClickButton('/write')}
-      >
-        글쓰기
-      </button>
-      <button
-        type="button"
-        onClick={() => handleClickButton('/chat')}
-      >
-        채팅
-      </button>
-    </Container>
+    <>
+      <Container>
+        <button
+          type="button"
+          onClick={navigateHome}
+        >
+          홈
+        </button>
+        <button
+          type="button"
+          onClick={() => navigatePage('/write')}
+        >
+          글쓰기
+        </button>
+        <button
+          type="button"
+          onClick={() => navigatePage('/chat')}
+        >
+          채팅
+        </button>
+      </Container>
+      <ModalLoginGuide
+        loginGuideModalState={loginGuideModalState}
+        setLoginGuideModalState={setLoginGuideModalState}
+        onClickLogin={navigateLogin}
+        onClickSelectTrialAccount={navigateSelectTrialAccount}
+      />
+    </>
   );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -33,10 +33,10 @@ const Side = styled.nav`
 `;
 
 export default function Header() {
+  const [accessToken, setAccessToken] = useLocalStorage('accessToken', '');
+
   const location = useLocation();
   const navigate = useNavigate();
-
-  const [accessToken, setAccessToken] = useLocalStorage('accessToken', '');
 
   const userStore = useUserStore();
 
@@ -62,8 +62,16 @@ export default function Header() {
     navigate('/');
   };
 
-  const navigateLoginPage = () => {
+  const navigateLogin = () => {
     navigate('/login', {
+      state: {
+        previousPath: location.pathname,
+      },
+    });
+  };
+
+  const navigateSelectTrialAccount = () => {
+    navigate('/trial-account', {
       state: {
         previousPath: location.pathname,
       },
@@ -95,12 +103,20 @@ export default function Header() {
             </button>
           </>
         ) : (
-          <button
-            type="button"
-            onClick={navigateLoginPage}
-          >
-            LOGIN
-          </button>
+          <>
+            <button
+              type="button"
+              onClick={navigateLogin}
+            >
+              LOGIN
+            </button>
+            <button
+              type="button"
+              onClick={navigateSelectTrialAccount}
+            >
+              체험용 계정 선택
+            </button>
+          </>
         )}
       </Side>
     </Container>

--- a/src/components/ModalLoginGuide.jsx
+++ b/src/components/ModalLoginGuide.jsx
@@ -1,0 +1,66 @@
+import ReactModal from 'react-modal';
+
+const modalStyle = {
+  overlay: {
+    backgroundColor: '#000000bb',
+  },
+  content: {
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    fontSize: '1.5em',
+    height: '12em',
+    width: '20em',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: '1em',
+  },
+};
+
+export default function ModalLoginGuide({
+  loginGuideModalState,
+  setLoginGuideModalState,
+  onClickLogin,
+  onClickSelectTrialAccount,
+}) {
+  const handleCloseModal = () => {
+    setLoginGuideModalState(false);
+  };
+
+  const handleClickLogin = () => {
+    onClickLogin();
+    handleCloseModal();
+  };
+
+  const handleClickSelectTrialAccount = () => {
+    onClickSelectTrialAccount();
+    handleCloseModal();
+  };
+
+  return (
+    <ReactModal
+      isOpen={loginGuideModalState}
+      onRequestClose={handleCloseModal}
+      style={modalStyle}
+    >
+      <p>
+        로그인이 필요합니다.
+      </p>
+      <button
+        type="button"
+        onClick={handleClickLogin}
+      >
+        로그인
+      </button>
+      <button
+        type="button"
+        onClick={handleClickSelectTrialAccount}
+      >
+        체험용 계정 선택
+      </button>
+    </ReactModal>
+  );
+}

--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -44,9 +44,9 @@ const LoginGuidance = styled.div`
 
 export default function Post({
   loggedIn,
-  navigateToBackward,
-  navigateToLogin,
-  navigateToSelectTrialAccount,
+  navigateBackward,
+  navigateLogin,
+  navigateSelectTrialAccount,
   post,
   game,
   members,
@@ -60,15 +60,15 @@ export default function Post({
   registerError,
 }) {
   const onClickBackward = () => {
-    navigateToBackward();
+    navigateBackward();
   };
 
   const onClickLogin = () => {
-    navigateToLogin();
+    navigateLogin();
   };
 
   const onClickSelectTrialAccount = () => {
-    navigateToSelectTrialAccount();
+    navigateSelectTrialAccount();
   };
 
   const onClickDeletePost = () => {

--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -33,11 +33,11 @@ export default function Posts({
   toggleSearchSetting,
   toggleFilterSetting,
   posts,
-  navigateToPost,
+  navigatePost,
   postsErrorMessage,
 }) {
   const onClickPost = (postId) => {
-    navigateToPost(postId);
+    navigatePost(postId);
   };
 
   return (
@@ -89,7 +89,6 @@ export default function Posts({
             </Thumbnail>
           ))}
         </Thumbnails>
-
       )}
     </Container>
   );

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -61,14 +61,22 @@ export default function PostPage() {
     navigate('/posts/list');
   };
 
-  const navigateToLogin = () => {
-    navigate('/login');
+  const navigateLogin = () => {
+    navigate('/login', {
+      state: {
+        previousPath: location.pathname,
+      },
+    });
   };
 
   // TODO: 체험 계정 선택하기 페이지로 이동시키기
 
-  const navigateToSelectTrialAccount = () => {
-    navigate('/login');
+  const navigateSelectTrialAccount = () => {
+    navigate('/login', {
+      state: {
+        previousPath: location.pathname,
+      },
+    });
   };
 
   const seeConfirmModal = ({ message }) => {
@@ -156,8 +164,8 @@ export default function PostPage() {
       <Post
         loggedIn={loggedIn}
         navigateBackward={navigateBackward}
-        navigateToLogin={navigateToLogin}
-        navigateToSelectTrialAccount={navigateToSelectTrialAccount}
+        navigateLogin={navigateLogin}
+        navigateSelectTrialAccount={navigateSelectTrialAccount}
         post={post}
         game={game}
         members={members}


### PR DESCRIPTION
현재 글 작성하기는 로그인하지 않은 상태에서도 버튼을 눌러 접근할 수 있는 문제가 있음
로그인을 유도하는 방식은 몇 가지가 있을 수 있겠는데
1. 로그인하지 않으면 애초에 글 작성하기를 띄우지 않거나
2. 글 작성하기는 항상 띄우되, 비로그인 상태에서 이동을 시도하면 그냥 로그인 화면으로 이동시키는 방식과
3. '로그인이 필요합니다. 로그인하기/체험용 계정 선택' Modal을 띄우는 방식 중에서 선택할 수 있을 것 같음

디자인 계획서 상에는 3번으로 계획되어 있어 3번 방식을 시도

3번 방식을 따르려면
하단 네비게이터는 어느 화면에서도 출력이 가능한 형태이기 때문에 Modal이 BottomNavigator에 정의되어야 할 것 같음
확인, 재확인 Modal과는 출력하려는 내용이 완전히 다르기 때문에 별도의 Modal 파일을 생성: ModalLoginGuide
함수를 구분할 필요 없이 바로 navigateLogin, navigateSelectTrialAccount로 보내는 함수만을 받아오도록 했음

<img width="717" alt="스크린샷 2022-12-04 오후 5 37 38" src="https://user-images.githubusercontent.com/50052512/205481617-ecf20be1-d034-4357-9acd-35504483a37b.png">
