### PR TITLE
알림 상세 보기 기능, 알림 상세 보기 시 상태를 읽은 상태로 변경

### DIFF
--- a/src/components/Notices.jsx
+++ b/src/components/Notices.jsx
@@ -18,25 +18,29 @@ const NoticeList = styled.ul`
   
 `;
 
-const Notice = styled.li`
+const NoticeTitle = styled.li`
   font-size: .75em;
   display: flex;
   gap: .5em;
 `;
 
+const NoticeDetail = styled.div`
+  
+`;
+
 export default function Notices({
   notices,
+  noticesDetailState,
+  showNoticeDetail,
   navigateBackward,
 }) {
   const onClickBackward = () => {
     navigateBackward();
   };
 
-  if (!notices || notices.length === 0) {
-    return (
-      <p>조회 가능한 알림이 없습니다.</p>
-    );
-  }
+  const handleClickShowNoticeDetail = (targetIndex) => {
+    showNoticeDetail(targetIndex);
+  };
 
   return (
     <Container>
@@ -48,14 +52,30 @@ export default function Notices({
           ⬅️
         </BackwardButton>
       </TopSection>
-      <NoticeList>
-        {notices.map((notice) => (
-          <Notice key={notice.id}>
-            <p>{notice.createdAt}</p>
-            <p>{notice.title}</p>
-          </Notice>
-        ))}
-      </NoticeList>
+      {(!notices || notices.length === 0) ? (
+        <p>조회 가능한 알림이 없습니다.</p>
+      ) : (
+        <NoticeList>
+          {notices.map((notice, index) => (
+            <>
+              <NoticeTitle key={notice.id}>
+                <button
+                  type="button"
+                  onClick={() => handleClickShowNoticeDetail(index)}
+                >
+                  <p>{notice.createdAt}</p>
+                  <p>{notice.title}</p>
+                </button>
+              </NoticeTitle>
+              {noticesDetailState[index] && (
+                <NoticeDetail>
+                  <p>{notice.detail}</p>
+                </NoticeDetail>
+              )}
+            </>
+          ))}
+        </NoticeList>
+      )}
     </Container>
   );
 }

--- a/src/pages/NoticesPage.jsx
+++ b/src/pages/NoticesPage.jsx
@@ -36,11 +36,21 @@ export default function NoticesPage() {
     noticeStore.fetchNotices();
   }, [accessToken]);
 
-  const { notices } = noticeStore;
+  const {
+    notices,
+    noticesDetailState,
+  } = noticeStore;
+
+  const showNoticeDetail = async (targetIndex) => {
+    await noticeStore.readNotice(targetIndex);
+    await noticeStore.showNoticeDetail(targetIndex);
+  };
 
   return (
     <Notices
       notices={notices}
+      noticesDetailState={noticesDetailState}
+      showNoticeDetail={showNoticeDetail}
       navigateBackward={navigateBackward}
     />
   );

--- a/src/services/NoticeApiService.js
+++ b/src/services/NoticeApiService.js
@@ -24,6 +24,11 @@ export default class NoticeApiService {
     });
     return data;
   }
+
+  async readNotice(noticeId) {
+    const url = `${apiBaseUrl}/notices/${noticeId}`;
+    await axios.patch(url);
+  }
 }
 
 export const noticeApiService = new NoticeApiService();

--- a/src/stores/NoticeStore.js
+++ b/src/stores/NoticeStore.js
@@ -5,6 +5,8 @@ export default class NoticeStore extends Store {
   constructor() {
     super();
 
+    this.noticesDetailState = [];
+
     this.notices = [];
     this.serverError = '';
   }
@@ -13,11 +15,26 @@ export default class NoticeStore extends Store {
     try {
       const data = await noticeApiService.fetchNotices();
       this.notices = data.notices;
+      this.noticesDetailState = Array(this.notices.length).fill(false);
       this.publish();
     } catch (error) {
       this.serverError = error.response.data;
       this.publish();
     }
+  }
+
+  async readNotice(targetIndex) {
+    const notice = this.notices
+      .find((_, index) => index === targetIndex);
+    if (notice && notice.status === 'unread') {
+      await noticeApiService.readNotice(notice.id);
+    }
+  }
+
+  showNoticeDetail(targetIndex) {
+    this.noticesDetailState = this.noticesDetailState
+      .map((_, index) => index === targetIndex);
+    this.publish();
   }
 }
 

--- a/src/stores/NoticeStore.test.js
+++ b/src/stores/NoticeStore.test.js
@@ -4,7 +4,14 @@ import NoticeStore from './NoticeStore';
 import { noticeApiService } from '../services/NoticeApiService';
 
 describe('NoticeStore', () => {
-  const noticeStore = new NoticeStore();
+  let noticeStore;
+  let spyReadNotice;
+
+  beforeEach(() => {
+    noticeStore = new NoticeStore();
+    spyReadNotice = jest.spyOn(noticeApiService, 'readNotice');
+    jest.clearAllMocks();
+  });
 
   context('API 서버에 접속한 사용자의 알림 목록을 요청할 경우', () => {
     it('웹 서버에서 응답으로 전달된 알림 목록을 상태로 저장', async () => {
@@ -20,6 +27,63 @@ describe('NoticeStore', () => {
       expect(notices[0].createdAt).toBe('6시간 전');
       expect(notices[1].title).toContain('새로운 참가 신청이 있습니다');
       expect(serverError).toBeFalsy();
+    });
+  });
+
+  context('알림의 상태를 읽음 상태로 변경 요청이 들어오는 경우', () => {
+    context('알림이 읽지 않음 상태였다면', () => {
+      beforeEach(() => {
+        noticeStore.notices = [
+          {
+            id: 1,
+            status: 'unread',
+            createdAt: '6시간 전',
+            title: '내가 신청한 운동 모집 게시글의 작성자가 신청을 수락했습니다.',
+            detail: '신청한 게임 시간',
+          },
+          {
+            id: 2,
+            status: 'read',
+            createdAt: '12시간 전',
+            title: '내가 작성한 운동 모집 게시글에 새로운 참가 신청이 있습니다.',
+            detail: '등록한 신청자: 황인우',
+          },
+        ];
+      });
+
+      it('알림을 읽음 상태로 변경하는 API 요청 호출', async () => {
+        const targetIndex = 0;
+        await noticeStore.readNotice(targetIndex);
+        const expectedNoticeId = 1;
+        expect(spyReadNotice).toBeCalledWith(expectedNoticeId);
+      });
+    });
+
+    context('알림이 읽음 상태였다면', () => {
+      beforeEach(() => {
+        noticeStore.notices = [
+          {
+            id: 1,
+            status: 'unread',
+            createdAt: '6시간 전',
+            title: '내가 신청한 운동 모집 게시글의 작성자가 신청을 수락했습니다.',
+            detail: '신청한 게임 시간',
+          },
+          {
+            id: 2,
+            status: 'read',
+            createdAt: '12시간 전',
+            title: '내가 작성한 운동 모집 게시글에 새로운 참가 신청이 있습니다.',
+            detail: '등록한 신청자: 황인우',
+          },
+        ];
+      });
+
+      it('알림을 읽음 상태로 변경하는 API 요청을 호출하지 않음', async () => {
+        const targetIndex = 1;
+        await noticeStore.readNotice(targetIndex);
+        expect(spyReadNotice).not.toBeCalled();
+      });
     });
   });
 });

--- a/src/stores/UserStore.test.js
+++ b/src/stores/UserStore.test.js
@@ -4,7 +4,6 @@ import UserStore from './UserStore';
 describe('UserStore', () => {
   let userStore;
   let spyLogin;
-  // let spyLogin;
 
   beforeEach(() => {
     userStore = new UserStore();

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -438,13 +438,17 @@ const postTestServer = setupServer(
             notices: [
               {
                 id: 1,
+                status: 'unread',
                 createdAt: '6시간 전',
                 title: '내가 신청한 운동 모집 게시글의 작성자가 신청을 수락했습니다.',
+                detail: '신청한 게임 시간',
               },
               {
                 id: 2,
+                status: 'read',
                 createdAt: '12시간 전',
                 title: '내가 작성한 운동 모집 게시글에 새로운 참가 신청이 있습니다.',
+                detail: '등록한 신청자: 황인우',
               },
             ],
             serverError: '',
@@ -458,34 +462,15 @@ const postTestServer = setupServer(
     },
   ),
 
-  // TODO: fetchUserName 테스트 코드 추가 필요 (Store, Component)
-
-  // TODO: 안 짠 테스트가 많다... 많나...?
-
-  // signUp
-  rest.post(
-    `${apiBaseUrl}/users`,
+  // readNotice
+  rest.patch(
+    `${apiBaseUrl}/notices/:noticeId`,
     async (request, response, context) => {
-      const {
-        name,
-        username,
-        password,
-        confirmPassword,
-        gender,
-        phoneNumber,
-      } = await request.json();
+      const { noticeId } = await request.params;
 
-      if (name === '황인우'
-        && username === 'hsjkdss228'
-        && password === 'Password!1'
-        && confirmPassword === 'Password!1'
-        && gender === '남성'
-        && phoneNumber === '01012345678') {
+      if (noticeId === '1') {
         return response(
-          context.status(201),
-          context.json({
-            enrolledName: '황인우',
-          }),
+          context.status(204),
         );
       }
 
@@ -493,6 +478,43 @@ const postTestServer = setupServer(
         context.status(400),
       );
     },
+
+    // TODO: fetchUserName 테스트 코드 추가 필요 (Store, Component)
+
+    // TODO: 안 짠 테스트가 많다... 많나...?
+
+    // signUp
+    rest.post(
+      `${apiBaseUrl}/users`,
+      async (request, response, context) => {
+        const {
+          name,
+          username,
+          password,
+          confirmPassword,
+          gender,
+          phoneNumber,
+        } = await request.json();
+
+        if (name === '황인우'
+        && username === 'hsjkdss228'
+        && password === 'Password!1'
+        && confirmPassword === 'Password!1'
+        && gender === '남성'
+        && phoneNumber === '01012345678') {
+          return response(
+            context.status(201),
+            context.json({
+              enrolledName: '황인우',
+            }),
+          );
+        }
+
+        return response(
+          context.status(400),
+        );
+      },
+    ),
   ),
 );
 


### PR DESCRIPTION
알림 목록에서 알림 하나를 클릭하면 -> 해당 알림 하단에 알림 상세 내용을 출력

NoticeStore에 fetch해오는 알림의 개수만큼 배열을 생성, 배열에는 boolean 값이 들어 있어 각 알림의 상세 정보 조회 상태를 관리
알림을 클릭해 상세 내용을 조회하려는 경우 배열의 해당 index의 boolean 값을 변경
알림 상세 보기 시 알림 상태를 읽음 상태로 전환하기 위해 해당 알림의 상태를 읽음으로 변경하는 API 요청을 같이 수행

https://github.com/hsjkdss228/smash-backend/pull/32

예상 뽀모 3
실제 뽀모 4