### PR TITLE
알림 목록에서 모든 알림/읽지 않은 알림 선택 확인, 헤더에서 읽지 않은 알림 개수 표시

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,9 +1,14 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
+
 import { useLocalStorage } from 'usehooks-ts';
+import styled from 'styled-components';
+
 import useUserStore from '../hooks/useUserStore';
+import useNoticeStore from '../hooks/useNoticeStore';
+
 import { userApiService } from '../services/UserApiService';
+import { noticeApiService } from '../services/NoticeApiService';
 
 const Container = styled.header`
   position: fixed;
@@ -32,6 +37,11 @@ const Side = styled.nav`
   gap: 1em;
 `;
 
+const UnreadNoticeCount = styled.span`
+  font-size: .5em;
+  color: #f00;
+`;
+
 export default function Header() {
   const [accessToken, setAccessToken] = useLocalStorage('accessToken', '');
 
@@ -39,15 +49,19 @@ export default function Header() {
   const navigate = useNavigate();
 
   const userStore = useUserStore();
+  const noticeStore = useNoticeStore();
+
+  const { unreadNoticeCount } = noticeStore;
+  const { name } = userStore;
 
   useEffect(() => {
     if (accessToken) {
       userApiService.setAccessToken(accessToken);
+      noticeApiService.setAccessToken(accessToken);
       userStore.fetchUserName();
+      noticeStore.fetchUnreadNoticeCount();
     }
   }, [accessToken]);
-
-  const { name } = userStore;
 
   const navigateNoticesPage = () => {
     navigate('/notices', {
@@ -94,6 +108,13 @@ export default function Header() {
               onClick={navigateNoticesPage}
             >
               알림
+              {(unreadNoticeCount >= 1) && (
+                <UnreadNoticeCount>
+                  (
+                  {unreadNoticeCount}
+                  )
+                </UnreadNoticeCount>
+              )}
             </button>
             <button
               type="button"

--- a/src/components/NoticeList.jsx
+++ b/src/components/NoticeList.jsx
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+
+const Container = styled.ul`
+  
+`;
+
+const Notice = styled.li`
+  
+`;
+
+const NoticeTitle = styled.div`
+  font-size: .75em;
+  display: flex;
+  gap: .5em;
+`;
+
+const NoticeDetail = styled.div`
+  
+`;
+
+export default function NoticeList({
+  notices,
+  noticeStateToShow,
+  noticesDetailState,
+  onClickShowNoticeDetail,
+  onClickCloseNoticeDetail,
+}) {
+  if (noticeStateToShow === 'unread' && notices.length === 0) {
+    return (
+      <p>읽지 않은 알림이 없습니다.</p>
+    );
+  }
+
+  return (
+    <Container>
+      {notices.map((notice, index) => (
+        <Notice key={notice.id}>
+          <NoticeTitle>
+            <button
+              type="button"
+              onClick={() => onClickShowNoticeDetail({
+                targetIndex: index,
+                targetId: notice.id,
+              })}
+            >
+              <p>
+                id:
+                {' '}
+                {notice.id}
+              </p>
+              <p>{notice.status}</p>
+              <p>{notice.createdAt}</p>
+              <p>{notice.title}</p>
+            </button>
+          </NoticeTitle>
+          {noticesDetailState[index] && (
+            <NoticeDetail>
+              <button
+                type="button"
+                onClick={() => onClickCloseNoticeDetail(index)}
+              >
+                닫기
+              </button>
+              <p>{notice.detail}</p>
+            </NoticeDetail>
+          )}
+        </Notice>
+      ))}
+    </Container>
+  );
+}

--- a/src/components/Notices.jsx
+++ b/src/components/Notices.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import NoticeList from './NoticeList';
 import BackwardButton from './ui/BackwardButton';
 
 const Container = styled.article`
@@ -14,33 +15,45 @@ const TopSection = styled.div`
   justify-content: space-between;
 `;
 
-const NoticeList = styled.ul`
-  
-`;
-
-const NoticeTitle = styled.li`
-  font-size: .75em;
-  display: flex;
-  gap: .5em;
-`;
-
-const NoticeDetail = styled.div`
+const Functions = styled.div`
   
 `;
 
 export default function Notices({
+  navigateBackward,
   notices,
+  noticeStateToShow,
+  showAll,
+  showUnreadOnly,
   noticesDetailState,
   showNoticeDetail,
-  navigateBackward,
+  closeNoticeDetail,
 }) {
   const onClickBackward = () => {
     navigateBackward();
   };
 
-  const handleClickShowNoticeDetail = (targetIndex) => {
-    showNoticeDetail(targetIndex);
+  const handleClickShowNoticeDetail = ({ targetIndex, targetId }) => {
+    showNoticeDetail({ targetIndex, targetId });
   };
+
+  const handleClickCloseNoticeDetail = (targetIndex) => {
+    closeNoticeDetail(targetIndex);
+  };
+
+  const handleClickShowAll = () => {
+    showAll();
+  };
+
+  const handleClickShowUnreadOnly = () => {
+    showUnreadOnly();
+  };
+
+  const filteredNotices = notices.filter((notice) => (
+    noticeStateToShow === 'unread'
+      ? notice.status === 'unread'
+      : notice
+  ));
 
   return (
     <Container>
@@ -51,30 +64,31 @@ export default function Notices({
         >
           ⬅️
         </BackwardButton>
+        <Functions>
+          <button
+            type="button"
+            onClick={handleClickShowAll}
+          >
+            모든 알림 확인
+          </button>
+          <button
+            type="button"
+            onClick={handleClickShowUnreadOnly}
+          >
+            읽지 않은 알림만 확인
+          </button>
+        </Functions>
       </TopSection>
       {(!notices || notices.length === 0) ? (
         <p>조회 가능한 알림이 없습니다.</p>
       ) : (
-        <NoticeList>
-          {notices.map((notice, index) => (
-            <>
-              <NoticeTitle key={notice.id}>
-                <button
-                  type="button"
-                  onClick={() => handleClickShowNoticeDetail(index)}
-                >
-                  <p>{notice.createdAt}</p>
-                  <p>{notice.title}</p>
-                </button>
-              </NoticeTitle>
-              {noticesDetailState[index] && (
-                <NoticeDetail>
-                  <p>{notice.detail}</p>
-                </NoticeDetail>
-              )}
-            </>
-          ))}
-        </NoticeList>
+        <NoticeList
+          notices={filteredNotices}
+          noticeStateToShow={noticeStateToShow}
+          noticesDetailState={noticesDetailState}
+          onClickShowNoticeDetail={handleClickShowNoticeDetail}
+          onClickCloseNoticeDetail={handleClickCloseNoticeDetail}
+        />
       )}
     </Container>
   );

--- a/src/components/Notices.test.jsx
+++ b/src/components/Notices.test.jsx
@@ -4,23 +4,38 @@ import Notices from './Notices';
 
 describe('Notices', () => {
   const navigateBackward = jest.fn();
+  const showAll = jest.fn();
+  const showUnreadOnly = jest.fn();
+  const showNoticeDetail = jest.fn();
+
   function renderNotices({
     notices,
+    noticeStateToShow,
+    noticesDetailState,
   }) {
     render((
       <Notices
-        notices={notices}
         navigateBackward={navigateBackward}
+        notices={notices}
+        noticeStateToShow={noticeStateToShow}
+        showAll={showAll}
+        showUnreadOnly={showUnreadOnly}
+        noticesDetailState={noticesDetailState}
+        showNoticeDetail={showNoticeDetail}
       />
     ));
   }
 
   context('알림 데이터가 없거나 불러와지지 않았으면', () => {
     const notices = [];
+    const noticeStateToShow = 'all';
+    const noticesDetailState = [];
 
     it('조회할 알림이 없다는 메시지 출력', () => {
       renderNotices({
         notices,
+        noticeStateToShow,
+        noticesDetailState,
       });
 
       screen.getByText(/조회 가능한 알림이 없습니다./);
@@ -31,23 +46,76 @@ describe('Notices', () => {
     const notices = [
       {
         id: 1,
+        status: 'unread',
         createdAt: '1시간 전',
         title: '내가 신청한 운동 모집 게시글의 작성자가 신청을 수락했습니다.',
+        detail: '신청한 게임 시간',
       },
       {
         id: 2,
+        status: 'read',
         createdAt: '2시간 전',
         title: '내가 작성한 운동 모집 게시글에 새로운 참가 신청이 있습니다.',
+        detail: '등록한 신청자: 황인우',
       },
     ];
+    const noticeStateToShow = 'all';
+    const noticesDetailState = [false, false];
 
     it('알림 리스트를 출력', () => {
       renderNotices({
         notices,
+        noticeStateToShow,
+        noticesDetailState,
       });
 
       screen.getByText(/작성자가 신청을 수락했습니다/);
       screen.getByText(/새로운 참가 신청이 있습니다/);
+    });
+
+    context('읽지 않은 알림만 조회하는 경우', () => {
+      const unread = 'unread';
+
+      it('전체 리스트에서 읽지 않은 상태의 알림만 리스트로 출력', () => {
+        renderNotices({
+          notices,
+          noticeStateToShow: unread,
+          noticesDetailState,
+        });
+
+        screen.getByText(/작성자가 신청을 수락했습니다/);
+        expect(screen.queryByText(/새로운 참가 신청이 있습니다/)).toBe(null);
+      });
+    });
+
+    context('읽지 않은 알림이 없을 경우', () => {
+      const noticesAllRead = [
+        {
+          id: 1,
+          status: 'read',
+          createdAt: '1시간 전',
+          title: '내가 신청한 운동 모집 게시글의 작성자가 신청을 수락했습니다.',
+          detail: '신청한 게임 시간',
+        },
+        {
+          id: 2,
+          status: 'read',
+          createdAt: '2시간 전',
+          title: '내가 작성한 운동 모집 게시글에 새로운 참가 신청이 있습니다.',
+          detail: '등록한 신청자: 황인우',
+        },
+      ];
+      const unread = 'unread';
+
+      it('읽지 않은 알림이 없다는 메시지를 출력', () => {
+        renderNotices({
+          notices: noticesAllRead,
+          noticeStateToShow: unread,
+          noticesDetailState,
+        });
+
+        screen.getByText(/읽지 않은 알림이 없습니다./);
+      });
     });
   });
 });

--- a/src/pages/NoticesPage.jsx
+++ b/src/pages/NoticesPage.jsx
@@ -38,20 +38,37 @@ export default function NoticesPage() {
 
   const {
     notices,
+    noticeStateToShow,
     noticesDetailState,
   } = noticeStore;
 
-  const showNoticeDetail = async (targetIndex) => {
-    await noticeStore.readNotice(targetIndex);
+  const showAll = async () => {
+    await noticeStore.showAll();
+  };
+
+  const showUnreadOnly = async () => {
+    await noticeStore.showUnreadOnly();
+  };
+
+  const showNoticeDetail = async ({ targetIndex, targetId }) => {
     await noticeStore.showNoticeDetail(targetIndex);
+    await noticeStore.readNotice(targetId);
+  };
+
+  const closeNoticeDetail = (targetIndex) => {
+    noticeStore.closeNoticeDetail(targetIndex);
   };
 
   return (
     <Notices
+      navigateBackward={navigateBackward}
       notices={notices}
+      noticeStateToShow={noticeStateToShow}
+      showAll={showAll}
+      showUnreadOnly={showUnreadOnly}
       noticesDetailState={noticesDetailState}
       showNoticeDetail={showNoticeDetail}
-      navigateBackward={navigateBackward}
+      closeNoticeDetail={closeNoticeDetail}
     />
   );
 }

--- a/src/services/NoticeApiService.js
+++ b/src/services/NoticeApiService.js
@@ -29,6 +29,17 @@ export default class NoticeApiService {
     const url = `${apiBaseUrl}/notices/${noticeId}`;
     await axios.patch(url);
   }
+
+  async fetchUnreadNoticeCount() {
+    const url = `${apiBaseUrl}/notice-count`;
+    const { data } = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+      params: { status: 'unread' },
+    });
+    return data;
+  }
 }
 
 export const noticeApiService = new NoticeApiService();

--- a/src/stores/NoticeStore.js
+++ b/src/stores/NoticeStore.js
@@ -5,9 +5,13 @@ export default class NoticeStore extends Store {
   constructor() {
     super();
 
+    this.noticeStateToShow = 'all';
     this.noticesDetailState = [];
 
     this.notices = [];
+
+    this.unreadNoticeCount = 0;
+
     this.serverError = '';
   }
 
@@ -23,17 +27,39 @@ export default class NoticeStore extends Store {
     }
   }
 
-  async readNotice(targetIndex) {
-    const notice = this.notices
-      .find((_, index) => index === targetIndex);
-    if (notice && notice.status === 'unread') {
-      await noticeApiService.readNotice(notice.id);
+  async readNotice(targetId) {
+    const found = this.notices
+      .find((notice) => notice.id === targetId);
+    if (found && found.status === 'unread') {
+      await noticeApiService.readNotice(found.id);
+      await this.fetchUnreadNoticeCount();
     }
+  }
+
+  async showAll() {
+    await this.fetchNotices();
+    this.noticeStateToShow = 'all';
+  }
+
+  async showUnreadOnly() {
+    await this.fetchNotices();
+    this.noticeStateToShow = 'unread';
   }
 
   showNoticeDetail(targetIndex) {
     this.noticesDetailState = this.noticesDetailState
       .map((_, index) => index === targetIndex);
+    this.publish();
+  }
+
+  closeNoticeDetail(targetIndex) {
+    this.noticesDetailState[targetIndex] = false;
+    this.publish();
+  }
+
+  async fetchUnreadNoticeCount() {
+    const data = await noticeApiService.fetchUnreadNoticeCount();
+    this.unreadNoticeCount = data.count;
     this.publish();
   }
 }


### PR DESCRIPTION
- 알림 목록 화면에서 '모든 알림 보기'를 선택할 경우 모든 알림 출력
- 알림 목록 화면에서 '읽지 않은 알림 보기'를 선택할 경우 읽지 않은 알림만 출력
- 알림 상세 보기 화면에서 닫기 버튼을 누를 경우 알림 상세 보기를 종료
- 헤더에서 읽지 않은 알림 개수를 표출