### PR TITLE
알림 목록에서 체크박스를 이용해 알림 선택

### DIFF
--- a/src/components/NoticeList.jsx
+++ b/src/components/NoticeList.jsx
@@ -24,6 +24,8 @@ export default function NoticeList({
   noticesDetailState,
   onClickShowNoticeDetail,
   onClickCloseNoticeDetail,
+  selectNoticeState,
+  onClickSelectNotice,
 }) {
   if (noticeStateToShow === 'unread' && notices.length === 0) {
     return (
@@ -36,6 +38,17 @@ export default function NoticeList({
       {notices.map((notice, index) => (
         <Notice key={notice.id}>
           <NoticeTitle>
+            {selectNoticeState && (
+              <input
+                type="checkbox"
+                id={notice.id}
+                value={notice.id}
+                onClick={() => onClickSelectNotice({
+                  targetIndex: index,
+                  targetId: notice.id,
+                })}
+              />
+            )}
             <button
               type="button"
               onClick={() => onClickShowNoticeDetail({

--- a/src/components/Notices.jsx
+++ b/src/components/Notices.jsx
@@ -28,9 +28,20 @@ export default function Notices({
   noticesDetailState,
   showNoticeDetail,
   closeNoticeDetail,
+  selectNoticeState,
+  toggleSelectNoticeState,
+  selectNotice,
 }) {
   const onClickBackward = () => {
     navigateBackward();
+  };
+
+  const handleClickShowAll = () => {
+    showAll();
+  };
+
+  const handleClickShowUnreadOnly = () => {
+    showUnreadOnly();
   };
 
   const handleClickShowNoticeDetail = ({ targetIndex, targetId }) => {
@@ -41,12 +52,12 @@ export default function Notices({
     closeNoticeDetail(targetIndex);
   };
 
-  const handleClickShowAll = () => {
-    showAll();
+  const handleClickToggleSelectNoticeState = () => {
+    toggleSelectNoticeState();
   };
 
-  const handleClickShowUnreadOnly = () => {
-    showUnreadOnly();
+  const handleClickSelectNotice = ({ targetIndex, targetId }) => {
+    selectNotice({ targetIndex, targetId });
   };
 
   const filteredNotices = notices.filter((notice) => (
@@ -65,6 +76,12 @@ export default function Notices({
           ⬅️
         </BackwardButton>
         <Functions>
+          <button
+            type="button"
+            onClick={handleClickToggleSelectNoticeState}
+          >
+            알림 선택
+          </button>
           <button
             type="button"
             onClick={handleClickShowAll}
@@ -88,6 +105,8 @@ export default function Notices({
           noticesDetailState={noticesDetailState}
           onClickShowNoticeDetail={handleClickShowNoticeDetail}
           onClickCloseNoticeDetail={handleClickCloseNoticeDetail}
+          selectNoticeState={selectNoticeState}
+          onClickSelectNotice={handleClickSelectNotice}
         />
       )}
     </Container>

--- a/src/pages/NoticesPage.jsx
+++ b/src/pages/NoticesPage.jsx
@@ -40,6 +40,7 @@ export default function NoticesPage() {
     notices,
     noticeStateToShow,
     noticesDetailState,
+    selectNoticeState,
   } = noticeStore;
 
   const showAll = async () => {
@@ -59,6 +60,14 @@ export default function NoticesPage() {
     noticeStore.closeNoticeDetail(targetIndex);
   };
 
+  const toggleSelectNoticeState = () => {
+    noticeStore.toggleSelectNoticeState();
+  };
+
+  const selectNotice = ({ targetIndex, targetId }) => {
+    noticeStore.selectNotice({ targetIndex, targetId });
+  };
+
   return (
     <Notices
       navigateBackward={navigateBackward}
@@ -69,6 +78,9 @@ export default function NoticesPage() {
       noticesDetailState={noticesDetailState}
       showNoticeDetail={showNoticeDetail}
       closeNoticeDetail={closeNoticeDetail}
+      selectNoticeState={selectNoticeState}
+      toggleSelectNoticeState={toggleSelectNoticeState}
+      selectNotice={selectNotice}
     />
   );
 }

--- a/src/stores/NoticeStore.js
+++ b/src/stores/NoticeStore.js
@@ -10,6 +10,9 @@ export default class NoticeStore extends Store {
 
     this.notices = [];
 
+    this.selectNoticeState = false;
+    this.noticesSelectedState = [];
+
     this.unreadNoticeCount = 0;
 
     this.serverError = '';
@@ -20,6 +23,7 @@ export default class NoticeStore extends Store {
       const data = await noticeApiService.fetchNotices();
       this.notices = data.notices;
       this.noticesDetailState = Array(this.notices.length).fill(false);
+      this.clearNoticesSelectedState();
       this.publish();
     } catch (error) {
       this.serverError = error.response.data;
@@ -39,11 +43,17 @@ export default class NoticeStore extends Store {
   async showAll() {
     await this.fetchNotices();
     this.noticeStateToShow = 'all';
+    this.selectNoticeState = false;
+    this.clearNoticesSelectedState();
+    this.publish();
   }
 
   async showUnreadOnly() {
     await this.fetchNotices();
     this.noticeStateToShow = 'unread';
+    this.selectNoticeState = false;
+    this.clearNoticesSelectedState();
+    this.publish();
   }
 
   showNoticeDetail(targetIndex) {
@@ -55,6 +65,24 @@ export default class NoticeStore extends Store {
   closeNoticeDetail(targetIndex) {
     this.noticesDetailState[targetIndex] = false;
     this.publish();
+  }
+
+  toggleSelectNoticeState() {
+    this.selectNoticeState = !this.selectNoticeState;
+    if (!this.selectedNoticeState) {
+      this.clearNoticesSelectedState();
+    }
+    this.publish();
+  }
+
+  selectNotice({ targetIndex, targetId }) {
+    this.noticesSelectedState[targetIndex] = this.noticesSelectedState[targetIndex]
+      ? ''
+      : targetId;
+  }
+
+  clearNoticesSelectedState() {
+    this.noticesSelectedState = Array(this.notices.length).fill('');
   }
 
   async fetchUnreadNoticeCount() {


### PR DESCRIPTION
- 최상단에 알림 선택 버튼 존재
- 알림 선택 버튼을 클릭하면 목록의 각 알림 좌측에 체크박스 출력
- 체크박스 클릭 시 선택된 알림의 id를 index에 맞춰 Store에 배열로 상태 저장
- 체크박스 해제 시 선택된 알림의 index에 해당하는 배열의 값을 비움
- 알림 조회 방식을 변경하거나 알림 선택 toggle을 비활성화할 경우 선택된 알림 배열 상태 초기화

예상 뽀모 2
실제 뽀모 2