### PR TITLE
알림 목록에서 전체 알림 선택

### DIFF
--- a/src/components/NoticeList.jsx
+++ b/src/components/NoticeList.jsx
@@ -25,7 +25,10 @@ export default function NoticeList({
   onClickShowNoticeDetail,
   onClickCloseNoticeDetail,
   selectNoticeState,
+  noticesSelectedState,
   onClickSelectNotice,
+  onClickSelectAllNotices,
+  onClickDeselectAllNotices,
 }) {
   if (noticeStateToShow === 'unread' && notices.length === 0) {
     return (
@@ -35,6 +38,22 @@ export default function NoticeList({
 
   return (
     <Container>
+      {selectNoticeState && (
+        <>
+          <button
+            type="button"
+            onClick={onClickSelectAllNotices}
+          >
+            전체선택
+          </button>
+          <button
+            type="button"
+            onClick={onClickDeselectAllNotices}
+          >
+            초기화
+          </button>
+        </>
+      )}
       {notices.map((notice, index) => (
         <Notice key={notice.id}>
           <NoticeTitle>
@@ -42,8 +61,8 @@ export default function NoticeList({
               <input
                 type="checkbox"
                 id={notice.id}
-                value={notice.id}
-                onClick={() => onClickSelectNotice({
+                checked={noticesSelectedState[index]}
+                onChange={() => onClickSelectNotice({
                   targetIndex: index,
                   targetId: notice.id,
                 })}

--- a/src/components/Notices.jsx
+++ b/src/components/Notices.jsx
@@ -30,7 +30,10 @@ export default function Notices({
   closeNoticeDetail,
   selectNoticeState,
   toggleSelectNoticeState,
+  noticesSelectedState,
   selectNotice,
+  selectAllNotices,
+  deselectAllNotices,
 }) {
   const onClickBackward = () => {
     navigateBackward();
@@ -60,11 +63,13 @@ export default function Notices({
     selectNotice({ targetIndex, targetId });
   };
 
-  const filteredNotices = notices.filter((notice) => (
-    noticeStateToShow === 'unread'
-      ? notice.status === 'unread'
-      : notice
-  ));
+  const handleClickSelectAllNotices = () => {
+    selectAllNotices();
+  };
+
+  const handleClickDeselectAllNotices = () => {
+    deselectAllNotices();
+  };
 
   return (
     <Container>
@@ -100,13 +105,16 @@ export default function Notices({
         <p>조회 가능한 알림이 없습니다.</p>
       ) : (
         <NoticeList
-          notices={filteredNotices}
+          notices={notices}
           noticeStateToShow={noticeStateToShow}
           noticesDetailState={noticesDetailState}
           onClickShowNoticeDetail={handleClickShowNoticeDetail}
           onClickCloseNoticeDetail={handleClickCloseNoticeDetail}
           selectNoticeState={selectNoticeState}
+          noticesSelectedState={noticesSelectedState}
           onClickSelectNotice={handleClickSelectNotice}
+          onClickSelectAllNotices={handleClickSelectAllNotices}
+          onClickDeselectAllNotices={handleClickDeselectAllNotices}
         />
       )}
     </Container>

--- a/src/pages/NoticesPage.jsx
+++ b/src/pages/NoticesPage.jsx
@@ -37,11 +37,17 @@ export default function NoticesPage() {
   }, [accessToken]);
 
   const {
-    notices,
+    noticesAll,
+    noticesUnread,
     noticeStateToShow,
     noticesDetailState,
     selectNoticeState,
+    noticesSelectedState,
   } = noticeStore;
+
+  const notices = noticeStateToShow === 'all'
+    ? noticesAll
+    : noticesUnread;
 
   const showAll = async () => {
     await noticeStore.showAll();
@@ -68,6 +74,14 @@ export default function NoticesPage() {
     noticeStore.selectNotice({ targetIndex, targetId });
   };
 
+  const selectAllNotices = () => {
+    noticeStore.selectAllNotices();
+  };
+
+  const deselectAllNotices = () => {
+    noticeStore.deselectAllNotices();
+  };
+
   return (
     <Notices
       navigateBackward={navigateBackward}
@@ -80,7 +94,10 @@ export default function NoticesPage() {
       closeNoticeDetail={closeNoticeDetail}
       selectNoticeState={selectNoticeState}
       toggleSelectNoticeState={toggleSelectNoticeState}
+      noticesSelectedState={noticesSelectedState}
       selectNotice={selectNotice}
+      selectAllNotices={selectAllNotices}
+      deselectAllNotices={deselectAllNotices}
     />
   );
 }


### PR DESCRIPTION
전체선택 시에는 알림 배열 전체를 돌면서 값을 mapping

배열의 값을 참고해 반대로 반전시키는 식의 변경은 이미 선택된 값이 있는 상태에서 전체선택을 했을 때 일괄 선택/일괄 해제가 되는 게 아닌 문제점이 있었음, 따라서 전체 선택, 초기화 버튼을 둬서 전체선택 시 무조건 전체 클릭, 초기화 시 무조건 전체를 취소하는 방식으로 구현

하나의 noticesAll 배열을 놓고 read, unread를 선택하는 방식으로 배열을 출력하게 하려다보니, noticesAll을 기준으로 만들어져 있는 선택된 배열 크기에 맞춰 전체선택이 이루어지는 문제가 있었음
이게 무슨 말이냐, 읽지 않은 알림만 보기를 누르면 전체 알림 중 일부만 화면에 나오는데, 전체 선택은 알림 전체를 기준으로 선택하기 때문에 읽지 않은 알림만 보는 상태에서 알림 전체 선택을 누르면 배열에 읽지 않은 알림뿐만 아니라 알림 전체의 id 값이 들어가는 문제가 있었음

그래서 모든 알림들과 읽지 않은 상태의 알림을 저장하는 배열을 나누고
페이지에서는 두 배열을 둘 다 꺼내오는데, 꺼낸 즉시 조회할 알림 상태가 무엇인지 검사해 (all인지 unread인지) 컴포넌트에 어떤 목록을 전달할지 결정

전체선택 취소 시에는 전체선택처럼 배열 전체를 돌면서 값을 비워줌

예상 뽀모 1
실제 뽀모 1.5