### PR TITLE
게시글 작성 Form 컴포넌트 디자인

### DIFF
--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -112,7 +112,7 @@ export default function LoginForm({
         />
       </Top>
       <LoginSection>
-        <Font>나만의 스포츠 매칭 시스템</Font>
+        <Font>우리들의 스포츠 매칭 시스템</Font>
         <Logo>
           SMASH
         </Logo>

--- a/src/components/ModalConfirm.jsx
+++ b/src/components/ModalConfirm.jsx
@@ -25,8 +25,12 @@ export default function ModalConfirm({
   confirmModalState,
   setConfirmModalState,
 }) {
-  const handleCloseModal = () => {
+  const closeModal = () => {
     setConfirmModalState(false);
+  };
+
+  const handleCloseModal = () => {
+    closeModal();
   };
 
   return (

--- a/src/components/ModalReconfirm.jsx
+++ b/src/components/ModalReconfirm.jsx
@@ -26,12 +26,17 @@ export default function ModalReconfirm({
   reconfirmModalState,
   setReconfirmModalState,
 }) {
+  const closeModal = () => {
+    setReconfirmModalState(false);
+  };
+
   const handleClickProgress = async () => {
     await action();
+    closeModal();
   };
 
   const handleCloseModal = () => {
-    setReconfirmModalState(false);
+    closeModal();
   };
 
   return (

--- a/src/components/PostForm.jsx
+++ b/src/components/PostForm.jsx
@@ -1,40 +1,43 @@
 /* eslint-disable no-nested-ternary */
 
 import 'react-datepicker/dist/react-datepicker.css';
+import { ko } from 'date-fns/esm/locale';
 
 import styled from 'styled-components';
 import DatePicker from 'react-datepicker';
 
 import Container from './ui/ComponentScreenContainer';
+import Section from './ui/ComponentSectionContainer';
 import SelectTime from './SelectTime';
 import BackwardButton from './BackwardButton';
+import PrimaryButton from './ui/PrimaryButton';
+import SecondaryButton from './ui/SecondaryButton';
+
+const Top = styled.div`
+  width: 100%;
+  margin-bottom: 1.5em;
+  display: flex;
+  justify-content: flex-start;
+`;
 
 const Form = styled.form`
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  section {
-    width: 80%;
-    padding: 1em;
-    border: 1px solid #000;
-    margin-block: .75em;
-  }
-`;
-
-const ExerciseSection = styled.section`
-  
 `;
 
 const TitleAndError = styled.div`
   display: flex;
   align-items: center;
   gap: 1em;
+  margin-bottom: 1em;
 `;
 
 const Label = styled.label`
-  font-size: 1.5em;
-  margin-bottom: .3em;
+  font-size: 1em;
+  font-weight: bold;
+  color: #FF7A63;
 `;
 
 const Error = styled.p`
@@ -44,11 +47,22 @@ const Error = styled.p`
 
 const TextInput = styled.input`
   width: 100%;
-`;
+  font-size: .9em;
+  padding: .7em;
+  border: ${({ hasError }) => (
+    hasError ? '1px solid #f00' : '1px solid #D8D8D8'
+  )};
+  margin-bottom: .3em;
 
-const DateAndTimeSection = styled.section`
-  span {
-    display: none;
+  :focus {
+    outline: none;
+  }
+
+  ::placeholder {
+    font-size: .8em;
+    color: ${({ hasError }) => (
+    hasError ? '#f00' : '#C0C0C0'
+  )};
   }
 `;
 
@@ -56,11 +70,63 @@ const DateSection = styled.div`
   margin-bottom: 1.5em;
 `;
 
+const DatePickerWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+
+  .react-datepicker {
+    border: none;
+  }
+
+  .react-datepicker__month-container {
+    width: 30em;
+  }
+
+  .react-datepicker__header {
+    background: none;
+    border-bottom: none;
+  }
+
+  .react-datepicker__day-name {
+    width: 3rem;
+  }
+
+  .react-datepicker__month {
+    margin-top: 0;
+  }
+
+  .react-datepicker__current-month {
+    font-size: 1.5em;
+    font-weight: 400;
+    padding-bottom: .7em;
+    color: #A0A0A0;
+  }
+
+  .react-datepicker__day-names {
+    padding-top: .5em;
+    border-top: 1px solid #BDBDBD;
+  }
+
+  .react-datepicker__day {
+    width: 3rem;
+  }
+
+  .react-datepicker__day--selected {
+    border-radius: 2em;
+    background-color: #FF7A63;
+  }
+`;
+
+const DateLabel = styled.label`
+  display: none;
+`;
+
 const TimeSection = styled.div`
   
 `;
 
 const Time = styled.div`
+  margin-bottom: .5em;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -72,35 +138,124 @@ const AmPm = styled.div`
   label {
     margin-right: .5em;
   }
+
+  input {
+    display: none;
+  }
+
+  span {
+    display: none;
+  }
+`;
+
+const AmButton = styled.button`
+  color: ${({ selectedState }) => (
+    selectedState === 'am'
+      ? '#fff'
+      : '#FF7A63'
+  )};
+  padding: .5em 1.25em;
+  border: ${({ selectedState }) => (
+    selectedState === 'am'
+      ? '1px solid transparent'
+      : '1px solid #CCC'
+  )};
+  border-radius: 5px;
+  margin-inline: .3em;
+  background-color: ${({ selectedState }) => (
+    selectedState === 'am'
+      ? '#FF7A63'
+      : '#fff'
+  )};
+
+  :hover {
+    color: #fff;
+    border-color: transparent;
+    background-color: #FF7A63;
+    cursor: pointer;
+  }
+
+  :active {
+    color: #fff;
+    border-color: transparent;
+    background-color: #090040;
+    cursor: pointer;
+  }
+`;
+
+const PmButton = styled.button`
+  color: ${({ selectedState }) => (
+    selectedState === 'pm'
+      ? '#fff'
+      : '#FF7A63'
+  )};
+  padding: .5em 1.25em;
+  border: ${({ selectedState }) => (
+    selectedState === 'pm'
+      ? '1px solid transparent'
+      : '1px solid #CCC'
+  )};
+  border-radius: 5px;
+  margin-inline: .3em;
+  background-color: ${({ selectedState }) => (
+    selectedState === 'pm'
+      ? '#FF7A63'
+      : '#fff'
+  )};
+
+  :hover {
+    color: #fff;
+    border-color: transparent;
+    background-color: #FF7A63;
+    cursor: pointer;
+  }
+
+  :active {
+    color: #fff;
+    border-color: transparent;
+    background-color: #090040;
+    cursor: pointer;
+  }
 `;
 
 const HourAndMinute = styled.div`
   display: flex;
+
   div {
     margin-inline: .3em;
   }
 `;
 
-const PlaceSection = styled.section`
-  
-`;
-
-const TargetMemberCountSection = styled.section`
-  
-`;
-
-const DetailSection = styled.section`
-
-`;
-
 const Textarea = styled.textarea`
   width: 100%;
+  font-size: .9em;
+  padding: .7em;
+  border: ${({ hasError }) => (
+    hasError ? '1px solid #f00' : '1px solid #D8D8D8'
+  )};
+  margin-bottom: .3em;
+
+  :focus {
+    outline: none;
+  }
+
+  ::placeholder {
+    font-size: 1em;
+    color: ${({ hasError }) => (
+    hasError ? '#f00' : '#C0C0C0'
+  )};
+  }
 `;
 
-const SubmitButton = styled.button`
-  font-size: 1.3em;
-  border: 1px solid #000;
-  padding: 1em 1.5em;
+const Buttons = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1em;
+
+  button {
+    padding: 1.25em;
+  }
 `;
 
 export default function PostForm({
@@ -117,6 +272,7 @@ export default function PostForm({
   changePlaceName,
   changeGameTargetMemberCount,
   changePostDetail,
+  resetForm,
   createPost,
   formErrors,
   serverError,
@@ -179,6 +335,10 @@ export default function PostForm({
     changePostDetail(value);
   };
 
+  const handleClickResetForm = () => {
+    resetForm();
+  };
+
   const handleSubmit = (event) => {
     event.preventDefault();
     createPost();
@@ -186,33 +346,40 @@ export default function PostForm({
 
   return (
     <Container>
-      <BackwardButton
-        onClick={handleClickBackward}
-      />
+      <Top>
+        <BackwardButton
+          onClick={handleClickBackward}
+        />
+      </Top>
       <Form onSubmit={handleSubmit}>
-        <ExerciseSection>
+        <Section>
           <TitleAndError>
             <Label htmlFor="input-game-exercise">
               종목
             </Label>
-            {formErrors.BLANK_GAME_EXERCISE ? (
-              <Error>{formErrors.BLANK_GAME_EXERCISE}</Error>
-            ) : null}
           </TitleAndError>
           <TextInput
             id="input-game-exercise"
             type="text"
-            placeholder="운동 종목 이름"
+            placeholder={(
+              formErrors.BLANK_GAME_EXERCISE ? (
+                formErrors.BLANK_GAME_EXERCISE
+              ) : '종목 이름을 입력해주세요.'
+            )}
             value={data.gameExercise}
             onChange={(event) => handleChangeGameExercise(event)}
+            hasError={formErrors.BLANK_GAME_EXERCISE}
           />
-        </ExerciseSection>
-        <DateAndTimeSection>
+        </Section>
+        <Section>
           <DateSection>
             <TitleAndError>
-              <Label htmlFor="input-game-date">
-                날짜
+              <Label>
+                날짜 및 시간
               </Label>
+              <DateLabel htmlFor="input-game-date">
+                날짜
+              </DateLabel>
               {formErrors.BLANK_GAME_START_AM_PM
                 || formErrors.BLANK_GAME_START_HOUR
                 || formErrors.BLANK_GAME_START_MINUTE
@@ -229,20 +396,22 @@ export default function PostForm({
                   </Error>
                 ) : null}
             </TitleAndError>
-            <DatePicker
-              id="input-game-date"
-              selected={data.gameDate}
-              onChange={(date) => handleChangeGameDate(date)}
-              dateFormat="yyyy년 MM월 dd일"
-            />
+            <DatePickerWrapper>
+              <DatePicker
+                id="input-game-date"
+                locale={ko}
+                minDate={new Date()}
+                selected={data.gameDate}
+                onChange={(date) => handleChangeGameDate(date)}
+                dateFormat="yyyy년 MM월 dd일"
+                inline
+              />
+            </DatePickerWrapper>
             {formErrors.BLANK_GAME_DATE ? (
               <Error>{formErrors.BLANK_GAME_DATE}</Error>
             ) : null}
           </DateSection>
           <TimeSection>
-            <Label>
-              시간
-            </Label>
             <Time>
               <AmPm>
                 <input
@@ -253,8 +422,16 @@ export default function PostForm({
                   onChange={handleChangeGameStartTimeAmPm}
                 />
                 <label htmlFor="input-game-start-time-am">
-                  <span>시작 </span>
-                  오전
+                  <AmButton
+                    className="input-game-start-time-am"
+                    selectedState={data.gameStartTimeAmPm}
+                    type="button"
+                    value="am"
+                    onClick={handleChangeGameStartTimeAmPm}
+                  >
+                    <span>시작 </span>
+                    오전
+                  </AmButton>
                 </label>
                 <input
                   id="input-game-start-time-pm"
@@ -264,8 +441,16 @@ export default function PostForm({
                   onChange={handleChangeGameStartTimeAmPm}
                 />
                 <label htmlFor="input-game-start-time-pm">
-                  <span>시작 </span>
-                  오후
+                  <PmButton
+                    className="input-game-start-time-pm"
+                    selectedState={data.gameStartTimeAmPm}
+                    type="button"
+                    value="pm"
+                    onClick={handleChangeGameStartTimeAmPm}
+                  >
+                    <span>시작 </span>
+                    오후
+                  </PmButton>
                 </label>
               </AmPm>
               <HourAndMinute>
@@ -297,8 +482,16 @@ export default function PostForm({
                   onChange={handleChangeGameEndTimeAmPm}
                 />
                 <label htmlFor="input-game-end-time-am">
-                  <span>종료 </span>
-                  오전
+                  <AmButton
+                    className="input-game-end-time-am"
+                    selectedState={data.gameEndTimeAmPm}
+                    type="button"
+                    value="am"
+                    onClick={handleChangeGameEndTimeAmPm}
+                  >
+                    <span>종료 </span>
+                    오전
+                  </AmButton>
                 </label>
                 <input
                   id="input-game-end-time-pm"
@@ -308,8 +501,16 @@ export default function PostForm({
                   onChange={handleChangeGameEndTimeAmPm}
                 />
                 <label htmlFor="input-game-end-time-pm">
-                  <span>종료 </span>
-                  오후
+                  <PmButton
+                    className="input-game-end-time-pm"
+                    selectedState={data.gameEndTimeAmPm}
+                    type="button"
+                    value="pm"
+                    onClick={handleChangeGameEndTimeAmPm}
+                  >
+                    <span>종료 </span>
+                    오후
+                  </PmButton>
                 </label>
               </AmPm>
               <HourAndMinute>
@@ -332,64 +533,84 @@ export default function PostForm({
               </HourAndMinute>
             </Time>
           </TimeSection>
-        </DateAndTimeSection>
-        <PlaceSection>
+        </Section>
+        <Section>
           <TitleAndError>
             <Label htmlFor="input-place-name">
               장소
             </Label>
-            {formErrors.BLANK_PLACE_NAME ? (
-              <Error>{formErrors.BLANK_PLACE_NAME}</Error>
-            ) : serverError.includes('주어진 장소 이름에 해당하는 장소를 찾을 수 없습니다') ? (
+            {serverError.includes('주어진 장소 이름에 해당하는 장소를 찾을 수 없습니다') && (
               <Error>등록되지 않은 장소입니다.</Error>
-            ) : null}
+            )}
           </TitleAndError>
           <TextInput
             id="input-place-name"
             type="text"
-            placeholder="운동 장소 이름"
+            placeholder={(
+              formErrors.BLANK_PLACE_NAME ? (
+                formErrors.BLANK_PLACE_NAME
+              ) : '장소 이름을 입력해주세요.'
+            )}
             value={data.placeName}
             onChange={handleChangePlaceName}
+            hasError={(
+              formErrors.BLANK_PLACE_NAME
+              || serverError.includes('주어진 장소 이름에 해당하는 장소를 찾을 수 없습니다')
+            )}
           />
-        </PlaceSection>
-        <TargetMemberCountSection>
+        </Section>
+        <Section>
           <TitleAndError>
             <Label htmlFor="input-game-target-member-count">
               모집 인원
             </Label>
-            {formErrors.NULL_GAME_TARGET_MEMBER_COUNT ? (
-              <Error>{formErrors.NULL_GAME_TARGET_MEMBER_COUNT}</Error>
-            ) : null}
           </TitleAndError>
           <TextInput
             id="input-game-target-member-count"
             type="number"
-            placeholder="운동 모집 인원 (2명 이상)"
+            placeholder={(
+              formErrors.NULL_GAME_TARGET_MEMBER_COUNT ? (
+                formErrors.NULL_GAME_TARGET_MEMBER_COUNT
+              ) : '운동 모집 인원 (2명 이상)'
+            )}
             value={data.gameTargetMemberCount}
             onChange={handleChangeGameTargetMemberCount}
+            hasError={formErrors.NULL_GAME_TARGET_MEMBER_COUNT}
           />
-        </TargetMemberCountSection>
-        <DetailSection>
+        </Section>
+        <Section>
           <TitleAndError>
             <Label htmlFor="input-post-detail">
               상세 내용
             </Label>
-            {formErrors.BLANK_POST_DETAIL ? (
-              <Error>{formErrors.BLANK_POST_DETAIL}</Error>
-            ) : null}
           </TitleAndError>
+          {/* TODO: 글자 수 제한 (2000자) 프론트엔드 및 백엔드 예외 처리 추가 */}
           <Textarea
             id="input-post-detail"
-            placeholder="운동 상세 내용을 입력해주세요."
+            placeholder={(
+              formErrors.BLANK_POST_DETAIL ? (
+                formErrors.BLANK_POST_DETAIL
+              ) : '운동 상세 내용을 입력해주세요.'
+            )}
+            rows="12"
             value={data.postDetail}
             onChange={handleChangePostDetail}
+            hasError={formErrors.BLANK_POST_DETAIL}
           />
-        </DetailSection>
-        <SubmitButton
-          type="submit"
-        >
-          작성하기
-        </SubmitButton>
+        </Section>
+        <Buttons>
+          <SecondaryButton
+            type="button"
+            onClick={handleClickResetForm}
+          >
+            초기화
+          </SecondaryButton>
+          <PrimaryButton
+            type="submit"
+          >
+            작성하기
+          </PrimaryButton>
+        </Buttons>
       </Form>
     </Container>
   );

--- a/src/components/SelectTime.jsx
+++ b/src/components/SelectTime.jsx
@@ -6,6 +6,10 @@ const Label = styled.label`
 
 const Input = styled.input`
   width: 2em;
+
+  ::placeholder {
+    text-align: center;
+  }
 `;
 
 export default function SelectTime({

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -189,6 +189,8 @@ export default function PostPage() {
           setConfirmModalState={setConfirmModalState}
         />
       )}
+      {/* TODO: Modal에 함수를 전달할 수 있음, 이렇게 지저분하게 전달하지 않아도 되므로
+            Github Project에 남긴 Modal 추가 Task를 보고 수정할 것 */}
       {reconfirmModalState && (
         <ModalReconfirm
           action={(

--- a/src/stores/PostFormStore.js
+++ b/src/stores/PostFormStore.js
@@ -41,21 +41,25 @@ export default class PostFormStore extends Store {
   }
 
   changeGameExercise(exercise) {
+    this.formErrors.BLANK_GAME_EXERCISE = '';
     this.gameExercise = exercise;
     this.publish();
   }
 
   changeGameDate(date) {
+    this.formErrors.BLANK_GAME_DATE = '';
     this.gameDate = date;
     this.publish();
   }
 
   changeGameStartTimeAmPm(startTimeAmPm) {
+    this.formErrors.BLANK_GAME_START_AM_PM = '';
     this.gameStartTimeAmPm = startTimeAmPm;
     this.publish();
   }
 
   changeGameStartHour(startHour) {
+    this.formErrors.BLANK_GAME_START_HOUR = '';
     if (startHour.toString().length === 0
       || !timeInputCheck.test(startHour.toString())) {
       this.gameStartHour = '';
@@ -77,6 +81,7 @@ export default class PostFormStore extends Store {
   }
 
   changeGameStartMinute(startMinute) {
+    this.formErrors.BLANK_GAME_START_MINUTE = '';
     if (startMinute.toString().length === 0
       || !timeInputCheck.test(startMinute)) {
       this.gameStartMinute = '';
@@ -98,11 +103,13 @@ export default class PostFormStore extends Store {
   }
 
   changeGameEndTimeAmPm(endTimeAmPm) {
+    this.formErrors.BLANK_GAME_END_AM_PM = '';
     this.gameEndTimeAmPm = endTimeAmPm;
     this.publish();
   }
 
   changeGameEndHour(endHour) {
+    this.formErrors.BLANK_GAME_END_HOUR = '';
     if (endHour.toString().length === 0
       || !timeInputCheck.test(endHour.toString())) {
       this.gameEndHour = '';
@@ -124,6 +131,7 @@ export default class PostFormStore extends Store {
   }
 
   changeGameEndMinute(endMinute) {
+    this.formErrors.BLANK_GAME_END_MINUTE = '';
     if (endMinute.toString().length === 0
       || !timeInputCheck.test(endMinute.toString())) {
       this.gameEndMinute = '';
@@ -145,16 +153,20 @@ export default class PostFormStore extends Store {
   }
 
   changePlaceName(place) {
+    this.formErrors.BLANK_PLACE_NAME = '';
+    this.clearServerError();
     this.placeName = place;
     this.publish();
   }
 
   changeGameTargetMemberCount(targetMemberCount) {
+    this.formErrors.NULL_GAME_TARGET_MEMBER_COUNT = '';
     this.gameTargetMemberCount = targetMemberCount;
     this.publish();
   }
 
   changePostDetail(detail) {
+    this.formErrors.BLANK_POST_DETAIL = '';
     this.postDetail = detail;
     this.publish();
   }
@@ -263,6 +275,10 @@ export default class PostFormStore extends Store {
     this.hasFormErrors = false;
   }
 
+  clearServerError() {
+    this.serverError = '';
+  }
+
   clearStates() {
     this.gameExercise = '';
     this.gameDate = new Date();
@@ -276,7 +292,6 @@ export default class PostFormStore extends Store {
     this.gameTargetMemberCount = '';
     this.postDetail = '';
     this.clearFormErrors();
-
     this.serverError = '';
 
     this.publish();


### PR DESCRIPTION
- 게시글 상세 내용 CSS에서 박스 양식 참조
  해당 박스 양식의 CSS를 별도의 컨테이너 파일로 분리하고, 필요 시 해당 컨테이너를 재호출해 재활용
- DatePicker의 마크업 구조와 class명을 기준으로 DatePicker의 커스텀 스타일링 진행
  날짜 선택 시 배경색상을 파란색에서 자몽색으로 변경했으나 Month 변경 시 선택된 날짜 기본 출력 배경색상이 자몽색으로 바뀌지 않는 문제가 있음
- Radio 버튼을 실제로는 보이지 않게 하고, Button을 클릭했을 때 Radio 버튼을 눌리는 것과 같게 하고, Button에 상태에 따라 다른 CSS가 적용되게 해 Radio 버튼을 대체
- 에러 메시지 상태를 Styled Component의 prop으로 전달해 상태에 따라 다른 CSS 속성 값을 적용

20221211
08:30-08:55 0.5뽀모
radio 버튼을 button으로 대체 중

사용 뽀모 5.5