### PR TITLE
프론트엔드 컴포넌트 리팩터링

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -55,6 +55,7 @@ const LoginLogoutButton = styled.button`
 
 const UnreadNoticeCount = styled.span`
   font-size: 1em;
+  font-weight: bold;
   color: #f00;
 `;
 
@@ -92,6 +93,14 @@ export default function Header() {
     navigate('/');
   };
 
+  const navigateMain = () => {
+    navigate('/', {
+      state: {
+        previousPath: location.pathname,
+      },
+    });
+  };
+
   const navigateLogin = () => {
     navigate('/login', {
       state: {
@@ -110,7 +119,14 @@ export default function Header() {
 
   return (
     <Container>
-      <Logo>SMASH</Logo>
+      <button
+        type="button"
+        onClick={navigateMain}
+      >
+        <Logo>
+          SMASH
+        </Logo>
+      </button>
       <Side>
         {accessToken ? (
           <>

--- a/src/components/NoticeDetail.jsx
+++ b/src/components/NoticeDetail.jsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+import useNoticeStore from '../hooks/useNoticeStore';
+
+const Container = styled.div`
+  padding: 1em;
+  border: 1px solid #CCC;
+  margin-inline: 1em;
+  background-color: #F9F9F9;
+  display: flex;
+  flex-direction: column;
+`;
+
+const DetailText = styled.p`
+  font-size: .8em;
+`;
+
+const CloseButton = styled.button`
+  color: #fff;
+  padding: .6em 1.4em;
+  border-radius: 5px;
+  align-self: flex-end;
+  background-color: #000;
+`;
+
+export default function NoticeDetail({
+  notice,
+  index,
+}) {
+  const noticeStore = useNoticeStore();
+
+  const handleClickCloseNoticeDetail = (targetIndex) => {
+    noticeStore.closeNoticeDetail(targetIndex);
+  };
+
+  return (
+    <Container>
+      <DetailText>
+        {notice.detail}
+      </DetailText>
+      <CloseButton
+        type="closeButton"
+        onClick={() => handleClickCloseNoticeDetail(index)}
+      >
+        닫기
+      </CloseButton>
+    </Container>
+  );
+}

--- a/src/components/NoticeFunctionsForSelected.jsx
+++ b/src/components/NoticeFunctionsForSelected.jsx
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+import useNoticeStore from '../hooks/useNoticeStore';
+
+import SecondaryButton from './ui/SecondaryButton';
+
+const Container = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export default function NoticeFunctionsForSelected() {
+  const noticeStore = useNoticeStore();
+
+  const handleClickReadSelectedNotices = async () => {
+    await noticeStore.readSelectedNotices();
+  };
+
+  const handleClickDeleteSelectedNotices = async () => {
+    await noticeStore.deleteSelectedNotices();
+  };
+
+  return (
+    <Container>
+      <SecondaryButton
+        type="button"
+        onClick={handleClickReadSelectedNotices}
+      >
+        읽은 알림으로 처리
+      </SecondaryButton>
+      <SecondaryButton
+        type="button"
+        onClick={handleClickDeleteSelectedNotices}
+      >
+        삭제
+      </SecondaryButton>
+    </Container>
+
+  );
+}

--- a/src/components/NoticeList.jsx
+++ b/src/components/NoticeList.jsx
@@ -1,173 +1,74 @@
-import styled from 'styled-components';
+/* eslint-disable no-nested-ternary */
 
-import Container from './ui/ComponentSectionContainer';
-import SecondaryButton from './ui/SecondaryButton';
+import { useEffect } from 'react';
+import styled from 'styled-components';
+import useNoticeStore from '../hooks/useNoticeStore';
+import NoticeFunctionsForSelected from './NoticeFunctionsForSelected';
+import NoticeSelectMethodButtons from './NoticeSelectMethodButtons';
+import NoticeTitle from './NoticeTitle';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
 
 const PaddingWrapper = styled.div`
   padding-block: .75em;
+`;
+
+const NoNotices = styled.p`
+  font-size: 1em;
+  font-weight: bold;
+  text-align: center;
+  margin-block: .5em 5em;
 `;
 
 const Notice = styled.li`
   list-style: none;
 `;
 
-const NoticeTitle = styled.div`
-  margin-top: ${({ selectedNoticeState }) => (
-    selectedNoticeState ? '1em' : '0'
-  )};
-  margin-bottom: 1.5em;
-  display: flex;
-`;
+export default function NoticeList() {
+  const noticeStore = useNoticeStore();
 
-const Checkbox = styled.input`
-  margin-right: 1.5em;
-`;
+  useEffect(() => {
+    noticeStore.closeSelectNoticeMode();
+    noticeStore.fetchNotices();
+  }, []);
 
-const NoticeTitleButton = styled.button`
-  display: flex;
-  flex-direction: column;
-`;
+  const {
+    noticesAll,
+    noticesUnread,
+    noticeStateToShown,
+    selectNoticeMode,
+  } = noticeStore;
 
-const CreatedAt = styled.p`
-  font-weight: bold;
-  text-align: left;
-  margin-bottom: .2em;
-`;
-
-const TitleText = styled.p`
-  font-size: .9em;
-  text-align: left;
-`;
-
-const NoticeDetail = styled.div`
-  padding: 1em;
-  border: 1px solid #CCC;
-  margin-inline: 1em;
-  background-color: #F9F9F9;
-  display: flex;
-  flex-direction: column;
-`;
-
-const DetailText = styled.p`
-  font-size: .8em;
-`;
-
-const CloseButton = styled.button`
-  color: #fff;
-  padding: .6em 1.4em;
-  border-radius: 5px;
-  align-self: flex-end;
-  background-color: #000;
-`;
-
-const ReadOrDeleteFunctions = styled.div`
-  display: flex;
-  justify-content: flex-end;
-`;
-
-export default function NoticeList({
-  notices,
-  noticeStateToShow,
-  noticesDetailState,
-  onClickShowNoticeDetail,
-  onClickCloseNoticeDetail,
-  selectNoticeState,
-  noticesSelectedState,
-  onClickSelectNotice,
-  onClickSelectAllNotices,
-  onClickDeselectAllNotices,
-  onClickReadSelectedNotices,
-  onClickDeleteSelectedNotices,
-}) {
-  if (noticeStateToShow === 'unread' && notices.length === 0) {
-    return (
-      <p>읽지 않은 알림이 없습니다.</p>
-    );
-  }
+  const notices = noticeStateToShown === 'all'
+    ? noticesAll
+    : noticesUnread;
 
   return (
-    <Container>
-      <PaddingWrapper>
-        {selectNoticeState && (
-          <div>
-            <SecondaryButton
-              type="button"
-              onClick={onClickSelectAllNotices}
-            >
-              전체선택
-            </SecondaryButton>
-            <SecondaryButton
-              type="button"
-              onClick={onClickDeselectAllNotices}
-            >
-              초기화
-            </SecondaryButton>
-          </div>
-        )}
-        {notices.map((notice, index) => (
-          <Notice key={notice.id}>
-            <NoticeTitle
-              selectedNoticeState={selectNoticeState}
-            >
-              {selectNoticeState && (
-                <Checkbox
-                  type="checkbox"
-                  id={notice.id}
-                  checked={noticesSelectedState[index]}
-                  onChange={() => onClickSelectNotice({
-                    targetIndex: index,
-                    targetId: notice.id,
-                  })}
-                />
-              )}
-              <NoticeTitleButton
-                type="button"
-                onClick={() => onClickShowNoticeDetail({
-                  targetIndex: index,
-                  targetId: notice.id,
-                })}
-              >
-                {/* TODO: 시간 출력 내용은 백엔드에서 처리되어야 함 */}
-                <CreatedAt>
-                  {(
-                    `${notice.createdAt.split('T')[0]} ${
-                      notice.createdAt.split('T')[1].split('.')[0]
-                    }`
-                  )}
-                </CreatedAt>
-                <TitleText>{notice.title}</TitleText>
-              </NoticeTitleButton>
-              {noticesDetailState[index] && (
-                <NoticeDetail>
-                  <DetailText>{notice.detail}</DetailText>
-                  <CloseButton
-                    type="closeButton"
-                    onClick={() => onClickCloseNoticeDetail(index)}
-                  >
-                    닫기
-                  </CloseButton>
-                </NoticeDetail>
-              )}
-            </NoticeTitle>
-          </Notice>
-        ))}
-        {selectNoticeState && (
-          <ReadOrDeleteFunctions>
-            <SecondaryButton
-              type="button"
-              onClick={onClickReadSelectedNotices}
-            >
-              읽은 알림으로 처리
-            </SecondaryButton>
-            <SecondaryButton
-              type="button"
-              onClick={onClickDeleteSelectedNotices}
-            >
-              삭제
-            </SecondaryButton>
-          </ReadOrDeleteFunctions>
-        )}
-      </PaddingWrapper>
-    </Container>
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
+      {noticeStateToShown === 'all' && (!notices || notices.length === 0) ? (
+        <NoNotices>조회 가능한 알림이 없습니다.</NoNotices>
+      ) : noticeStateToShown === 'unread' && notices.length === 0 ? (
+        <NoNotices>읽지 않은 알림이 없습니다.</NoNotices>
+      ) : (
+        <PaddingWrapper>
+          {selectNoticeMode && (
+            <NoticeSelectMethodButtons />
+          )}
+          {notices.map((notice, index) => (
+            <Notice key={notice.id}>
+              <NoticeTitle
+                notice={notice}
+                index={index}
+              />
+            </Notice>
+          ))}
+          {selectNoticeMode && (
+            <NoticeFunctionsForSelected />
+          )}
+        </PaddingWrapper>
+      )}
+    </ComponentSectionContainer>
   );
 }

--- a/src/components/NoticeSelectMethodButtons.jsx
+++ b/src/components/NoticeSelectMethodButtons.jsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import useNoticeStore from '../hooks/useNoticeStore';
+
+import SecondaryButton from './ui/SecondaryButton';
+
+const Container = styled.div`
+  margin-bottom: 1.5em;
+`;
+
+export default function NoticeSelectMethodButtons() {
+  const noticeStore = useNoticeStore();
+
+  const handleClickSelectAllNotices = () => {
+    noticeStore.selectAllNotices();
+  };
+
+  const handleClickDeselectAllNotices = () => {
+    noticeStore.deselectAllNotices();
+  };
+
+  return (
+    <Container>
+      <SecondaryButton
+        type="button"
+        onClick={handleClickSelectAllNotices}
+      >
+        전체선택
+      </SecondaryButton>
+      <SecondaryButton
+        type="button"
+        onClick={handleClickDeselectAllNotices}
+      >
+        초기화
+      </SecondaryButton>
+    </Container>
+  );
+}

--- a/src/components/NoticeSettings.jsx
+++ b/src/components/NoticeSettings.jsx
@@ -1,0 +1,88 @@
+import styled from 'styled-components';
+
+import useNoticeStore from '../hooks/useNoticeStore';
+
+const ToggleButton = styled.button`
+  color: ${({ selected }) => (
+    selected ? '#fff' : '#FF7A63'
+  )};
+  padding: .5em 1.25em;
+  border: ${({ selected }) => (
+    selected ? '1px solid transparent' : '1px solid #CCC'
+  )};
+  border-radius: 5px;
+  margin-inline: .3em;
+  background-color: ${({ selected }) => (
+    selected ? '#FF7A63' : '#fff'
+  )};
+
+  :hover {
+    color: #fff;
+    border-color: transparent;
+    background-color: #FF7A63;
+  }
+
+  :active {
+    color: #fff;
+    border-color: transparent;
+    background-color: #090040;
+  }
+`;
+
+const Container = styled.div`
+  
+`;
+
+export default function NoticeSettings() {
+  const noticeStore = useNoticeStore();
+
+  const {
+    selectNoticeMode,
+    showAllNoticesMode,
+    showUnreadNoticesMode,
+  } = noticeStore;
+
+  const handleClickSelectNoticeMode = () => {
+    noticeStore.toggleSelectNoticeMode();
+  };
+
+  const handleClickShowAll = async () => {
+    if (showAllNoticesMode) {
+      return;
+    }
+    await noticeStore.showAll();
+  };
+
+  const handleClickShowUnreadOnly = async () => {
+    if (showUnreadNoticesMode) {
+      return;
+    }
+    await noticeStore.showUnreadOnly();
+  };
+
+  return (
+    <Container>
+      <ToggleButton
+        type="button"
+        selected={selectNoticeMode}
+        onClick={handleClickSelectNoticeMode}
+      >
+        알림 선택
+      </ToggleButton>
+      <ToggleButton
+        type="button"
+        selected={showAllNoticesMode}
+        onClick={handleClickShowAll}
+      >
+        모든 알림 확인
+      </ToggleButton>
+      <ToggleButton
+        type="button"
+        selected={showUnreadNoticesMode}
+        onClick={handleClickShowUnreadOnly}
+      >
+        읽지 않은 알림만 확인
+      </ToggleButton>
+    </Container>
+  );
+}

--- a/src/components/NoticeTitle.jsx
+++ b/src/components/NoticeTitle.jsx
@@ -1,0 +1,100 @@
+import styled from 'styled-components';
+
+import useNoticeStore from '../hooks/useNoticeStore';
+import NoticeDetail from './NoticeDetail';
+
+const Container = styled.div`
+  margin-bottom: ${({ isSelectNoticeMode }) => (
+    isSelectNoticeMode ? '1.5em' : '1em'
+  )};
+  display: flex;
+`;
+
+const Checkbox = styled.input`
+  margin-right: 1.5em;
+`;
+
+const NoticeTitleButton = styled.button`
+  display: flex;
+  flex-direction: column;
+`;
+
+const CreatedAt = styled.p`
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: .2em;
+`;
+
+const TitleText = styled.p`
+  font-size: .9em;
+  text-align: left;
+`;
+
+export default function NoticeTitle({
+  notice,
+  index,
+}) {
+  const noticeStore = useNoticeStore();
+
+  const {
+    selectNoticeMode,
+    selectedNotices,
+    isOpenedNotice,
+  } = noticeStore;
+
+  const handleSelectNotice = ({
+    targetIndex,
+    targetId,
+  }) => {
+    noticeStore.selectNotice({ targetIndex, targetId });
+  };
+
+  const handleClickNoticeTitle = async ({
+    targetIndex,
+    targetId,
+  }) => {
+    await noticeStore.showNoticeDetail(targetIndex);
+    await noticeStore.readNotice(targetId);
+  };
+
+  return (
+    <Container
+      isSelectNoticeMode={selectNoticeMode}
+    >
+      {selectNoticeMode && (
+        <Checkbox
+          type="checkbox"
+          id={notice.id}
+          checked={selectedNotices[index]}
+          onChange={() => handleSelectNotice({
+            targetIndex: index,
+            targetId: notice.id,
+          })}
+        />
+      )}
+      <NoticeTitleButton
+        type="button"
+        onClick={() => handleClickNoticeTitle({
+          targetIndex: index,
+          targetId: notice.id,
+        })}
+      >
+        {/* TODO: 시간 출력 내용은 백엔드에서 처리되어야 함 */}
+        <CreatedAt>
+          {(`${notice.createdAt.split('T')[0]} ${
+            notice.createdAt.split('T')[1].split('.')[0]
+          }`)}
+        </CreatedAt>
+        <TitleText>
+          {notice.title}
+        </TitleText>
+      </NoticeTitleButton>
+      {isOpenedNotice[index] && (
+        <NoticeDetail
+          notice={notice}
+          index={index}
+        />
+      )}
+    </Container>
+  );
+}

--- a/src/components/Notices.jsx
+++ b/src/components/Notices.jsx
@@ -1,180 +1,34 @@
 import styled from 'styled-components';
 
-import { useState } from 'react';
-
 import Container from './ui/ComponentScreenContainer';
 import BackwardButton from './BackwardButton';
 import NoticeList from './NoticeList';
-import ComponentSectionContainer from './ui/ComponentSectionContainer';
+import NoticeSettings from './NoticeSettings';
 
-const TopSection = styled.div`
+const BackwardAndSettings = styled.div`
   width: 100%;
+  margin-bottom: 1.5em;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1em;
-`;
-
-const ToggleButton = styled.button`
-  color: ${({ toggledState }) => (
-    toggledState ? '#fff' : '#FF7A63'
-  )};
-  padding: .5em 1.25em;
-  border: ${({ toggledState }) => (
-    toggledState ? '1px solid transparent' : '1px solid #CCC'
-  )};
-  border-radius: 5px;
-  margin-inline: .3em;
-  background-color: ${({ toggledState }) => (
-    toggledState ? '#FF7A63' : '#fff'
-  )};
-
-  :hover {
-    color: #fff;
-    border-color: transparent;
-    background-color: #FF7A63;
-  }
-
-  :active {
-    color: #fff;
-    border-color: transparent;
-    background-color: #090040;
-  }
-`;
-
-const Functions = styled.div`
-  
-`;
-
-const GuardWrapper = styled.div`
-  font-size: .9em;
-  font-weight: bold;
-  text-align: center;
 `;
 
 export default function Notices({
   navigateBackward,
-  notices,
-  noticeStateToShow,
-  showAll,
-  showUnreadOnly,
-  noticesDetailState,
-  showNoticeDetail,
-  closeNoticeDetail,
-  selectNoticeState,
-  toggleSelectNoticeState,
-  noticesSelectedState,
-  selectNotice,
-  selectAllNotices,
-  deselectAllNotices,
-  readSelectedNotices,
-  deleteSelectedNotices,
 }) {
-  const [selectNoticeButtonState, setSelectNoticeButtonState] = useState(false);
-  const [allNoticesButtonState, setAllNoticesButtonState] = useState(true);
-  const [unreadNoticesButtonState, setUnreadNoticesButtonState] = useState(false);
-
-  const onClickBackward = () => {
+  const handleClickBackward = () => {
     navigateBackward();
-  };
-
-  const handleClickShowAll = () => {
-    showAll();
-    setAllNoticesButtonState(true);
-    setUnreadNoticesButtonState(false);
-  };
-
-  const handleClickShowUnreadOnly = () => {
-    showUnreadOnly();
-    setAllNoticesButtonState(false);
-    setUnreadNoticesButtonState(true);
-  };
-
-  const handleClickShowNoticeDetail = ({ targetIndex, targetId }) => {
-    showNoticeDetail({ targetIndex, targetId });
-  };
-
-  const handleClickCloseNoticeDetail = (targetIndex) => {
-    closeNoticeDetail(targetIndex);
-  };
-
-  const handleClickToggleSelectNoticeState = () => {
-    toggleSelectNoticeState();
-    setSelectNoticeButtonState(!selectNoticeButtonState);
-  };
-
-  const handleClickSelectNotice = ({ targetIndex, targetId }) => {
-    selectNotice({ targetIndex, targetId });
-  };
-
-  const handleClickSelectAllNotices = () => {
-    selectAllNotices();
-  };
-
-  const handleClickDeselectAllNotices = () => {
-    deselectAllNotices();
-  };
-
-  const handleClickReadSelectedNotices = () => {
-    readSelectedNotices();
-  };
-
-  const handleClickDeleteSelectedNotices = () => {
-    deleteSelectedNotices();
   };
 
   return (
     <Container>
-      <TopSection>
+      <BackwardAndSettings>
         <BackwardButton
-          onClick={onClickBackward}
+          onClick={handleClickBackward}
         />
-        <Functions>
-          <ToggleButton
-            type="button"
-            toggledState={selectNoticeButtonState}
-            onClick={handleClickToggleSelectNoticeState}
-          >
-            알림 선택
-          </ToggleButton>
-          <ToggleButton
-            type="button"
-            toggledState={allNoticesButtonState}
-            onClick={handleClickShowAll}
-          >
-            모든 알림 확인
-          </ToggleButton>
-          <ToggleButton
-            type="button"
-            toggledState={unreadNoticesButtonState}
-            onClick={handleClickShowUnreadOnly}
-          >
-            읽지 않은 알림만 확인
-          </ToggleButton>
-        </Functions>
-      </TopSection>
-      {(!notices || notices.length === 0) ? (
-        <ComponentSectionContainer>
-          <GuardWrapper>
-            <p>조회 가능한 알림이 없습니다.</p>
-          </GuardWrapper>
-        </ComponentSectionContainer>
-      ) : (
-        <NoticeList
-          notices={notices}
-          noticeStateToShow={noticeStateToShow}
-          noticesDetailState={noticesDetailState}
-          onClickShowNoticeDetail={handleClickShowNoticeDetail}
-          onClickCloseNoticeDetail={handleClickCloseNoticeDetail}
-          selectNoticeState={selectNoticeState}
-          noticesSelectedState={noticesSelectedState}
-          onClickSelectNotice={handleClickSelectNotice}
-          onClickSelectAllNotices={handleClickSelectAllNotices}
-          onClickDeselectAllNotices={handleClickDeselectAllNotices}
-          onClickReadSelectedNotices={handleClickReadSelectedNotices}
-          onClickDeleteSelectedNotices={handleClickDeleteSelectedNotices}
-        />
-      )}
+        <NoticeSettings />
+      </BackwardAndSettings>
+      <NoticeList />
     </Container>
   );
 }

--- a/src/components/PostAuthor.jsx
+++ b/src/components/PostAuthor.jsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import usePostStore from '../hooks/usePostStore';
+
 const Container = styled.section`
   margin: 0 1em 1em;
   display: grid;
@@ -12,7 +14,9 @@ const AuthorProfile = styled.div`
   margin-right: 2em;
 
   img {
+    height: 12em;
     width: 12em;
+    object-fit: cover;
     border-radius: 100%;
   }
 `;
@@ -51,33 +55,32 @@ const SeeProfile = styled.button`
   }
 `;
 
-export default function PostAuthor({
-  authorName,
-  authorPhoneNumber,
-  authorProfileImageUrl,
-  authorMannerScore,
-}) {
+export default function PostAuthor() {
+  const postStore = usePostStore();
+
+  const { post } = postStore;
+
   return (
     <Container>
       <AuthorProfile>
         <img
-          src={authorProfileImageUrl}
+          src={post.authorInformation.profileImageUrl}
           alt="사용자 프로필 이미지"
         />
       </AuthorProfile>
       <AuthorInformation>
         <AuthorName>
-          {authorName}
+          {post.authorInformation.name}
         </AuthorName>
         <AuthorPhoneNumber>
-          {authorPhoneNumber}
+          {post.authorInformation.phoneNumber}
         </AuthorPhoneNumber>
       </AuthorInformation>
       <AuthorScoreAndSeeProfile>
         <Score>
           평점:
           {' '}
-          {authorMannerScore}
+          {post.authorInformation.mannerScore}
         </Score>
         <SeeProfile
           type="button"

--- a/src/components/PostAuthorMenu.jsx
+++ b/src/components/PostAuthorMenu.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+import styled from 'styled-components';
+
+import usePostStore from '../hooks/usePostStore';
+import ModalReconfirm from './ModalReconfirm';
+
+import Button from './ui/PrimaryButton';
+
+const Container = styled.div`
+  
+`;
+
+export default function PostAuthorMenu({
+  navigatePostsAfterDeleted,
+}) {
+  const [actionMessage, setActionMessage] = useState('');
+  const [postIdToBeDeleted, setPostIdToBeDeleted] = useState(0);
+  const [reconfirmModalState, setReconfirmModalState] = useState(false);
+
+  const postStore = usePostStore();
+
+  const { post } = postStore;
+
+  const deletePost = async () => {
+    await postStore.deletePost(postIdToBeDeleted);
+    navigatePostsAfterDeleted();
+  };
+
+  const seeReconfirmModal = ({ message }) => {
+    setActionMessage(message);
+    setReconfirmModalState(true);
+  };
+
+  const reconfirmDeletePost = (targetPostId) => {
+    setPostIdToBeDeleted(targetPostId);
+    seeReconfirmModal({ message: '게시글을 삭제' });
+  };
+
+  const onClickDeletePost = () => {
+    reconfirmDeletePost(post.id);
+  };
+
+  return (
+    <>
+      <Container>
+        <Button
+          type="button"
+        >
+          수정하기
+        </Button>
+        <Button
+          type="button"
+          onClick={onClickDeletePost}
+        >
+          삭제하기
+        </Button>
+      </Container>
+      {reconfirmModalState && (
+        <ModalReconfirm
+          action={deletePost}
+          actionMessage={actionMessage}
+          reconfirmModalState={reconfirmModalState}
+          setReconfirmModalState={setReconfirmModalState}
+        />
+      )}
+    </>
+
+  );
+}

--- a/src/components/PostContent.jsx
+++ b/src/components/PostContent.jsx
@@ -1,0 +1,17 @@
+import PostAuthor from './PostAuthor';
+import PostDetail from './PostDetail';
+import PostImages from './PostImages';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
+
+export default function PostContent() {
+  return (
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
+      <PostAuthor />
+      <PostDetail />
+      <PostImages />
+    </ComponentSectionContainer>
+  );
+}

--- a/src/components/PostDetail.jsx
+++ b/src/components/PostDetail.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import usePostStore from '../hooks/usePostStore';
 
 const Container = styled.section`
   font-size: .8em;
@@ -8,12 +9,22 @@ const Container = styled.section`
   line-height: 1.2;
 `;
 
-export default function PostDetail({
-  detail,
-}) {
+const Detail = styled.pre`
+  white-space: pre-wrap;
+  word-break: keep-all;
+  overflow: auto;
+`;
+
+export default function PostDetail() {
+  const postStore = usePostStore();
+
+  const { post } = postStore;
+
   return (
     <Container>
-      {detail}
+      <Detail>
+        {post.detail}
+      </Detail>
     </Container>
   );
 }

--- a/src/components/PostForm.jsx
+++ b/src/components/PostForm.jsx
@@ -1,17 +1,22 @@
-/* eslint-disable no-nested-ternary */
-
-import 'react-datepicker/dist/react-datepicker.css';
-import { ko } from 'date-fns/esm/locale';
-
 import styled from 'styled-components';
-import DatePicker from 'react-datepicker';
 
-import Container from './ui/ComponentScreenContainer';
-import Section from './ui/ComponentSectionContainer';
-import SelectTime from './SelectTime';
+import { useEffect, useState } from 'react';
+
+import usePostFormStore from '../hooks/usePostFormStore';
+
+import ComponentScreenContainer from './ui/ComponentScreenContainer';
+
 import BackwardButton from './BackwardButton';
 import PrimaryButton from './ui/PrimaryButton';
 import SecondaryButton from './ui/SecondaryButton';
+
+import PostFormExerciseName from './PostFormExerciseName';
+import PostFormDateTimeSection from './PostFormDateTimeSection';
+import PostFormPlace from './PostFormPlace';
+import PostFormTargetMemberCount from './PostFormTargetMemberCount';
+import PostFormDetail from './PostFormDetail';
+
+import ModalReconfirm from './ModalReconfirm';
 
 const Top = styled.div`
   width: 100%;
@@ -27,226 +32,6 @@ const Form = styled.form`
   align-items: center;
 `;
 
-const TitleAndError = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1em;
-  margin-bottom: 1em;
-`;
-
-const Label = styled.label`
-  font-size: 1em;
-  font-weight: bold;
-  color: #FF7A63;
-`;
-
-const Error = styled.p`
-  font-size: .8em;
-  color: #f00;
-`;
-
-const TextInput = styled.input`
-  width: 100%;
-  font-size: .9em;
-  padding: .7em;
-  border: ${({ hasError }) => (
-    hasError ? '1px solid #f00' : '1px solid #D8D8D8'
-  )};
-  margin-bottom: .3em;
-
-  :focus {
-    outline: none;
-  }
-
-  ::placeholder {
-    font-size: .8em;
-    color: ${({ hasError }) => (
-    hasError ? '#f00' : '#C0C0C0'
-  )};
-  }
-`;
-
-const DateSection = styled.div`
-  margin-bottom: 1.5em;
-`;
-
-const DatePickerWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-
-  .react-datepicker {
-    border: none;
-  }
-
-  .react-datepicker__month-container {
-    width: 30em;
-  }
-
-  .react-datepicker__header {
-    background: none;
-    border-bottom: none;
-  }
-
-  .react-datepicker__day-name {
-    width: 3rem;
-  }
-
-  .react-datepicker__month {
-    margin-top: 0;
-  }
-
-  .react-datepicker__current-month {
-    font-size: 1.5em;
-    font-weight: 400;
-    padding-bottom: .7em;
-    color: #A0A0A0;
-  }
-
-  .react-datepicker__day-names {
-    padding-top: .5em;
-    border-top: 1px solid #BDBDBD;
-  }
-
-  .react-datepicker__day {
-    width: 3rem;
-  }
-
-  .react-datepicker__day--selected {
-    border-radius: 2em;
-    background-color: #FF7A63;
-  }
-`;
-
-const DateLabel = styled.label`
-  display: none;
-`;
-
-const TimeSection = styled.div`
-  
-`;
-
-const Time = styled.div`
-  margin-bottom: .5em;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const AmPm = styled.div`
-  margin-right: .5em;
-
-  label {
-    margin-right: .5em;
-  }
-
-  input {
-    display: none;
-  }
-
-  span {
-    display: none;
-  }
-`;
-
-const AmButton = styled.button`
-  color: ${({ selectedState }) => (
-    selectedState === 'am'
-      ? '#fff'
-      : '#FF7A63'
-  )};
-  padding: .5em 1.25em;
-  border: ${({ selectedState }) => (
-    selectedState === 'am'
-      ? '1px solid transparent'
-      : '1px solid #CCC'
-  )};
-  border-radius: 5px;
-  margin-inline: .3em;
-  background-color: ${({ selectedState }) => (
-    selectedState === 'am'
-      ? '#FF7A63'
-      : '#fff'
-  )};
-
-  :hover {
-    color: #fff;
-    border-color: transparent;
-    background-color: #FF7A63;
-    cursor: pointer;
-  }
-
-  :active {
-    color: #fff;
-    border-color: transparent;
-    background-color: #090040;
-    cursor: pointer;
-  }
-`;
-
-const PmButton = styled.button`
-  color: ${({ selectedState }) => (
-    selectedState === 'pm'
-      ? '#fff'
-      : '#FF7A63'
-  )};
-  padding: .5em 1.25em;
-  border: ${({ selectedState }) => (
-    selectedState === 'pm'
-      ? '1px solid transparent'
-      : '1px solid #CCC'
-  )};
-  border-radius: 5px;
-  margin-inline: .3em;
-  background-color: ${({ selectedState }) => (
-    selectedState === 'pm'
-      ? '#FF7A63'
-      : '#fff'
-  )};
-
-  :hover {
-    color: #fff;
-    border-color: transparent;
-    background-color: #FF7A63;
-    cursor: pointer;
-  }
-
-  :active {
-    color: #fff;
-    border-color: transparent;
-    background-color: #090040;
-    cursor: pointer;
-  }
-`;
-
-const HourAndMinute = styled.div`
-  display: flex;
-
-  div {
-    margin-inline: .3em;
-  }
-`;
-
-const Textarea = styled.textarea`
-  width: 100%;
-  font-size: .9em;
-  padding: .7em;
-  border: ${({ hasError }) => (
-    hasError ? '1px solid #f00' : '1px solid #D8D8D8'
-  )};
-  margin-bottom: .3em;
-
-  :focus {
-    outline: none;
-  }
-
-  ::placeholder {
-    font-size: 1em;
-    color: ${({ hasError }) => (
-    hasError ? '#f00' : '#C0C0C0'
-  )};
-  }
-`;
-
 const Buttons = styled.div`
   width: 100%;
   display: grid;
@@ -259,359 +44,102 @@ const Buttons = styled.div`
 `;
 
 export default function PostForm({
-  data,
-  reconfirmNavigateBackward,
-  changeGameExercise,
-  changeGameDate,
-  changeGameStartTimeAmPm,
-  changeGameStartHour,
-  changeGameStartMinute,
-  changeGameEndTimeAmPm,
-  changeGameEndHour,
-  changeGameEndMinute,
-  changePlaceName,
-  changeGameTargetMemberCount,
-  changePostDetail,
-  resetForm,
-  createPost,
-  formErrors,
-  serverError,
+  navigateBackward,
+  navigatePostsAfterCreated,
 }) {
+  const [action, setAction] = useState(null);
+  const [actionMessage, setActionMessage] = useState('');
+  const [reconfirmModalState, setReconfirmModalState] = useState(false);
+
+  const postFormStore = usePostFormStore();
+
+  useEffect(() => {
+    postFormStore.clearStates();
+  }, []);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const postId = await postFormStore.createPost();
+    if (postId) {
+      postFormStore.clearStates();
+      navigatePostsAfterCreated();
+    }
+  };
+
+  const resetForm = () => {
+    postFormStore.clearStates();
+  };
+
+  const resetFormAndNavigateBackward = () => {
+    resetForm();
+    navigateBackward();
+  };
+
+  const seeReconfirmModal = ({ targetAction, message }) => {
+    setAction(targetAction);
+    setActionMessage(message);
+    setReconfirmModalState(true);
+  };
+
+  const reconfirmNavigateBackward = () => {
+    seeReconfirmModal({
+      targetAction: () => resetFormAndNavigateBackward,
+      message: '게시글 작성을 중단',
+    });
+  };
+
+  const reconfirmResetForm = () => {
+    seeReconfirmModal({
+      targetAction: () => resetForm,
+      message: '입력 내용을 초기화',
+    });
+  };
+
   const handleClickBackward = () => {
     reconfirmNavigateBackward();
   };
 
-  const handleChangeGameExercise = (event) => {
-    const { value } = event.target;
-    changeGameExercise(value);
-  };
-
-  const handleChangeGameDate = (date) => {
-    changeGameDate(date);
-  };
-
-  const handleChangeGameStartTimeAmPm = (event) => {
-    const { value } = event.target;
-    changeGameStartTimeAmPm(value);
-  };
-
-  const handleChangeGameStartHour = (event) => {
-    const { value } = event.target;
-    changeGameStartHour(value);
-  };
-
-  const handleChangeGameStartMinute = (event) => {
-    const { value } = event.target;
-    changeGameStartMinute(value);
-  };
-
-  const handleChangeGameEndTimeAmPm = (event) => {
-    const { value } = event.target;
-    changeGameEndTimeAmPm(value);
-  };
-
-  const handleChangeGameEndHour = (event) => {
-    const { value } = event.target;
-    changeGameEndHour(value);
-  };
-
-  const handleChangeGameEndMinute = (event) => {
-    const { value } = event.target;
-    changeGameEndMinute(value);
-  };
-
-  const handleChangePlaceName = (event) => {
-    const { value } = event.target;
-    changePlaceName(value);
-  };
-
-  const handleChangeGameTargetMemberCount = (event) => {
-    const { value } = event.target;
-    changeGameTargetMemberCount(value);
-  };
-
-  const handleChangePostDetail = (event) => {
-    const { value } = event.target;
-    changePostDetail(value);
-  };
-
   const handleClickResetForm = () => {
-    resetForm();
-  };
-
-  const handleSubmit = (event) => {
-    event.preventDefault();
-    createPost();
+    reconfirmResetForm();
   };
 
   return (
-    <Container>
-      <Top>
-        <BackwardButton
-          onClick={handleClickBackward}
+    <>
+      <ComponentScreenContainer>
+        <Top>
+          <BackwardButton
+            onClick={handleClickBackward}
+          />
+        </Top>
+        <Form onSubmit={handleSubmit}>
+          <PostFormExerciseName />
+          <PostFormDateTimeSection />
+          <PostFormPlace />
+          <PostFormTargetMemberCount />
+          <PostFormDetail />
+          <Buttons>
+            <SecondaryButton
+              type="button"
+              onClick={handleClickResetForm}
+            >
+              초기화
+            </SecondaryButton>
+            <PrimaryButton
+              type="submit"
+            >
+              작성하기
+            </PrimaryButton>
+          </Buttons>
+        </Form>
+      </ComponentScreenContainer>
+      {reconfirmModalState && (
+        <ModalReconfirm
+          action={action}
+          actionMessage={actionMessage}
+          reconfirmModalState={reconfirmModalState}
+          setReconfirmModalState={setReconfirmModalState}
         />
-      </Top>
-      <Form onSubmit={handleSubmit}>
-        <Section>
-          <TitleAndError>
-            <Label htmlFor="input-game-exercise">
-              종목
-            </Label>
-          </TitleAndError>
-          <TextInput
-            id="input-game-exercise"
-            type="text"
-            placeholder={(
-              formErrors.BLANK_GAME_EXERCISE ? (
-                formErrors.BLANK_GAME_EXERCISE
-              ) : '종목 이름을 입력해주세요.'
-            )}
-            value={data.gameExercise}
-            onChange={(event) => handleChangeGameExercise(event)}
-            hasError={formErrors.BLANK_GAME_EXERCISE}
-          />
-        </Section>
-        <Section>
-          <DateSection>
-            <TitleAndError>
-              <Label>
-                날짜 및 시간
-              </Label>
-              <DateLabel htmlFor="input-game-date">
-                날짜
-              </DateLabel>
-              {formErrors.BLANK_GAME_START_AM_PM
-                || formErrors.BLANK_GAME_START_HOUR
-                || formErrors.BLANK_GAME_START_MINUTE
-                || formErrors.BLANK_GAME_END_AM_PM
-                || formErrors.BLANK_GAME_END_HOUR
-                || formErrors.BLANK_GAME_END_MINUTE ? (
-                  <Error>
-                    {(formErrors.BLANK_GAME_START_AM_PM
-                    || formErrors.BLANK_GAME_END_AM_PM
-                    || formErrors.BLANK_GAME_START_HOUR
-                    || formErrors.BLANK_GAME_END_HOUR
-                    || formErrors.BLANK_GAME_START_MINUTE
-                    || formErrors.BLANK_GAME_END_MINUTE)}
-                  </Error>
-                ) : null}
-            </TitleAndError>
-            <DatePickerWrapper>
-              <DatePicker
-                id="input-game-date"
-                locale={ko}
-                minDate={new Date()}
-                selected={data.gameDate}
-                onChange={(date) => handleChangeGameDate(date)}
-                dateFormat="yyyy년 MM월 dd일"
-                inline
-              />
-            </DatePickerWrapper>
-            {formErrors.BLANK_GAME_DATE ? (
-              <Error>{formErrors.BLANK_GAME_DATE}</Error>
-            ) : null}
-          </DateSection>
-          <TimeSection>
-            <Time>
-              <AmPm>
-                <input
-                  id="input-game-start-time-am"
-                  type="radio"
-                  name="start-time-am-pm"
-                  value="am"
-                  onChange={handleChangeGameStartTimeAmPm}
-                />
-                <label htmlFor="input-game-start-time-am">
-                  <AmButton
-                    className="input-game-start-time-am"
-                    selectedState={data.gameStartTimeAmPm}
-                    type="button"
-                    value="am"
-                    onClick={handleChangeGameStartTimeAmPm}
-                  >
-                    <span>시작 </span>
-                    오전
-                  </AmButton>
-                </label>
-                <input
-                  id="input-game-start-time-pm"
-                  type="radio"
-                  name="start-time-am-pm"
-                  value="pm"
-                  onChange={handleChangeGameStartTimeAmPm}
-                />
-                <label htmlFor="input-game-start-time-pm">
-                  <PmButton
-                    className="input-game-start-time-pm"
-                    selectedState={data.gameStartTimeAmPm}
-                    type="button"
-                    value="pm"
-                    onClick={handleChangeGameStartTimeAmPm}
-                  >
-                    <span>시작 </span>
-                    오후
-                  </PmButton>
-                </label>
-              </AmPm>
-              <HourAndMinute>
-                <SelectTime
-                  id="input-game-start-hour"
-                  onChange={handleChangeGameStartHour}
-                  type="start"
-                  time="hour"
-                  value={data.gameStartHour}
-                />
-                <p>:</p>
-                <SelectTime
-                  id="input-game-start-minute"
-                  onChange={handleChangeGameStartMinute}
-                  type="start"
-                  time="minute"
-                  value={data.gameStartMinute}
-                />
-              </HourAndMinute>
-              <p>부터</p>
-            </Time>
-            <Time>
-              <AmPm>
-                <input
-                  id="input-game-end-time-am"
-                  type="radio"
-                  name="end-time-am-pm"
-                  value="am"
-                  onChange={handleChangeGameEndTimeAmPm}
-                />
-                <label htmlFor="input-game-end-time-am">
-                  <AmButton
-                    className="input-game-end-time-am"
-                    selectedState={data.gameEndTimeAmPm}
-                    type="button"
-                    value="am"
-                    onClick={handleChangeGameEndTimeAmPm}
-                  >
-                    <span>종료 </span>
-                    오전
-                  </AmButton>
-                </label>
-                <input
-                  id="input-game-end-time-pm"
-                  type="radio"
-                  name="end-time-am-pm"
-                  value="pm"
-                  onChange={handleChangeGameEndTimeAmPm}
-                />
-                <label htmlFor="input-game-end-time-pm">
-                  <PmButton
-                    className="input-game-end-time-pm"
-                    selectedState={data.gameEndTimeAmPm}
-                    type="button"
-                    value="pm"
-                    onClick={handleChangeGameEndTimeAmPm}
-                  >
-                    <span>종료 </span>
-                    오후
-                  </PmButton>
-                </label>
-              </AmPm>
-              <HourAndMinute>
-                <SelectTime
-                  id="input-game-end-hour"
-                  onChange={handleChangeGameEndHour}
-                  type="end"
-                  time="hour"
-                  value={data.gameEndHour}
-                />
-                <p>:</p>
-                <SelectTime
-                  id="input-game-end-minute"
-                  onChange={handleChangeGameEndMinute}
-                  type="end"
-                  time="minute"
-                  value={data.gameEndMinute}
-                />
-                <p>까지</p>
-              </HourAndMinute>
-            </Time>
-          </TimeSection>
-        </Section>
-        <Section>
-          <TitleAndError>
-            <Label htmlFor="input-place-name">
-              장소
-            </Label>
-            {serverError.includes('주어진 장소 이름에 해당하는 장소를 찾을 수 없습니다') && (
-              <Error>등록되지 않은 장소입니다.</Error>
-            )}
-          </TitleAndError>
-          <TextInput
-            id="input-place-name"
-            type="text"
-            placeholder={(
-              formErrors.BLANK_PLACE_NAME ? (
-                formErrors.BLANK_PLACE_NAME
-              ) : '장소 이름을 입력해주세요.'
-            )}
-            value={data.placeName}
-            onChange={handleChangePlaceName}
-            hasError={(
-              formErrors.BLANK_PLACE_NAME
-              || serverError.includes('주어진 장소 이름에 해당하는 장소를 찾을 수 없습니다')
-            )}
-          />
-        </Section>
-        <Section>
-          <TitleAndError>
-            <Label htmlFor="input-game-target-member-count">
-              모집 인원
-            </Label>
-          </TitleAndError>
-          <TextInput
-            id="input-game-target-member-count"
-            type="number"
-            placeholder={(
-              formErrors.NULL_GAME_TARGET_MEMBER_COUNT ? (
-                formErrors.NULL_GAME_TARGET_MEMBER_COUNT
-              ) : '운동 모집 인원 (2명 이상)'
-            )}
-            value={data.gameTargetMemberCount}
-            onChange={handleChangeGameTargetMemberCount}
-            hasError={formErrors.NULL_GAME_TARGET_MEMBER_COUNT}
-          />
-        </Section>
-        <Section>
-          <TitleAndError>
-            <Label htmlFor="input-post-detail">
-              상세 내용
-            </Label>
-          </TitleAndError>
-          {/* TODO: 글자 수 제한 (2000자) 프론트엔드 및 백엔드 예외 처리 추가 */}
-          <Textarea
-            id="input-post-detail"
-            placeholder={(
-              formErrors.BLANK_POST_DETAIL ? (
-                formErrors.BLANK_POST_DETAIL
-              ) : '운동 상세 내용을 입력해주세요.'
-            )}
-            rows="12"
-            value={data.postDetail}
-            onChange={handleChangePostDetail}
-            hasError={formErrors.BLANK_POST_DETAIL}
-          />
-        </Section>
-        <Buttons>
-          <SecondaryButton
-            type="button"
-            onClick={handleClickResetForm}
-          >
-            초기화
-          </SecondaryButton>
-          <PrimaryButton
-            type="submit"
-          >
-            작성하기
-          </PrimaryButton>
-        </Buttons>
-      </Form>
-    </Container>
+      )}
+    </>
   );
 }

--- a/src/components/PostFormDate.jsx
+++ b/src/components/PostFormDate.jsx
@@ -1,0 +1,98 @@
+import 'react-datepicker/dist/react-datepicker.css';
+import { ko } from 'date-fns/esm/locale';
+
+import styled from 'styled-components';
+
+import DatePicker from 'react-datepicker';
+
+import usePostFormStore from '../hooks/usePostFormStore';
+
+const Container = styled.div`
+  
+`;
+
+const DateSection = styled.div`
+  margin-bottom: 1.5em;
+`;
+
+const DatePickerWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+
+  .react-datepicker {
+    border: none;
+  }
+
+  .react-datepicker__month-container {
+    width: 30em;
+  }
+
+  .react-datepicker__header {
+    background: none;
+    border-bottom: none;
+  }
+
+  .react-datepicker__day-name {
+    width: 3rem;
+  }
+
+  .react-datepicker__month {
+    margin-top: 0;
+  }
+
+  .react-datepicker__current-month {
+    font-size: 1.5em;
+    font-weight: 400;
+    padding-bottom: .7em;
+    color: #A0A0A0;
+  }
+
+  .react-datepicker__day-names {
+    padding-top: .5em;
+    border-top: 1px solid #BDBDBD;
+  }
+
+  .react-datepicker__day {
+    width: 3rem;
+  }
+
+  .react-datepicker__day--selected {
+    border-radius: 2em;
+    background-color: #FF7A63;
+  }
+`;
+
+const DateLabel = styled.label`
+  display: none;
+`;
+
+export default function PostFormDate() {
+  const postFormStore = usePostFormStore();
+
+  const { gameDate } = postFormStore;
+
+  const handleChangeGameDate = (date) => {
+    postFormStore.changeGameDate(date);
+  };
+
+  return (
+    <Container>
+      <DateSection>
+        <DateLabel htmlFor="input-game-date">
+          날짜
+        </DateLabel>
+        <DatePickerWrapper>
+          <DatePicker
+            id="input-game-date"
+            locale={ko}
+            minDate={new Date()}
+            selected={gameDate}
+            onChange={(date) => handleChangeGameDate(date)}
+            dateFormat="yyyy년 MM월 dd일"
+            inline
+          />
+        </DatePickerWrapper>
+      </DateSection>
+    </Container>
+  );
+}

--- a/src/components/PostFormDateTimeSection.jsx
+++ b/src/components/PostFormDateTimeSection.jsx
@@ -1,0 +1,65 @@
+/* eslint-disable no-nested-ternary */
+
+import styled from 'styled-components';
+
+import usePostFormStore from '../hooks/usePostFormStore';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
+
+import PostFormDate from './PostFormDate';
+import PostFormTime from './PostFormTime';
+
+const TitleAndError = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+`;
+
+const Label = styled.label`
+  font-size: 1em;
+  font-weight: bold;
+  color: #FF7A63;
+`;
+
+const Error = styled.p`
+  font-size: .8em;
+  color: #f00;
+`;
+
+export default function PostForm() {
+  const postFormStore = usePostFormStore();
+
+  const { formErrors } = postFormStore;
+
+  return (
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
+      <TitleAndError>
+        <Label>
+          날짜 및 시간
+        </Label>
+        {(formErrors.BLANK_GAME_DATE
+          || formErrors.BLANK_GAME_START_AM_PM
+          || formErrors.BLANK_GAME_START_HOUR
+          || formErrors.BLANK_GAME_START_MINUTE
+          || formErrors.BLANK_GAME_END_AM_PM
+          || formErrors.BLANK_GAME_END_HOUR
+          || formErrors.BLANK_GAME_END_MINUTE) && (
+          <Error>
+            {(formErrors.BLANK_GAME_DATE
+              || formErrors.BLANK_GAME_START_AM_PM
+              || formErrors.BLANK_GAME_END_AM_PM
+              || formErrors.BLANK_GAME_START_HOUR
+              || formErrors.BLANK_GAME_END_HOUR
+              || formErrors.BLANK_GAME_START_MINUTE
+              || formErrors.BLANK_GAME_END_MINUTE)}
+          </Error>
+        )}
+      </TitleAndError>
+      <PostFormDate />
+      <PostFormTime />
+    </ComponentSectionContainer>
+  );
+}

--- a/src/components/PostFormDetail.jsx
+++ b/src/components/PostFormDetail.jsx
@@ -1,0 +1,77 @@
+import styled from 'styled-components';
+import usePostFormStore from '../hooks/usePostFormStore';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
+
+const TitleAndError = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+`;
+
+const Label = styled.label`
+  font-size: 1em;
+  font-weight: bold;
+  color: #FF7A63;
+`;
+
+const Textarea = styled.textarea`
+  width: 100%;
+  font-size: .9em;
+  padding: .7em;
+  border: ${({ hasError }) => (
+    hasError ? '1px solid #f00' : '1px solid #D8D8D8'
+  )};
+  margin-bottom: .3em;
+
+  :focus {
+    outline: none;
+  }
+
+  ::placeholder {
+    font-size: 1em;
+    color: ${({ hasError }) => (
+    hasError ? '#f00' : '#C0C0C0'
+  )};
+  }
+`;
+
+export default function PostFormDetail() {
+  const postFormStore = usePostFormStore();
+
+  const {
+    postDetail,
+    formErrors,
+  } = postFormStore;
+
+  const handleChangePostDetail = (event) => {
+    const { value } = event.target;
+    postFormStore.changePostDetail(value);
+  };
+
+  return (
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
+      <TitleAndError>
+        <Label htmlFor="input-post-detail">
+          상세 내용
+        </Label>
+      </TitleAndError>
+      {/* TODO: 글자 수 제한 (2000자) 프론트엔드 및 백엔드 예외 처리 추가 */}
+      <Textarea
+        id="input-post-detail"
+        placeholder={(
+          formErrors.BLANK_POST_DETAIL ? (
+            formErrors.BLANK_POST_DETAIL
+          ) : '운동 상세 내용을 입력해주세요.'
+        )}
+        rows="12"
+        value={postDetail}
+        onChange={handleChangePostDetail}
+        hasError={formErrors.BLANK_POST_DETAIL}
+      />
+    </ComponentSectionContainer>
+  );
+}

--- a/src/components/PostFormExerciseName.jsx
+++ b/src/components/PostFormExerciseName.jsx
@@ -1,0 +1,76 @@
+import styled from 'styled-components';
+import usePostFormStore from '../hooks/usePostFormStore';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
+
+const TitleAndError = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+`;
+
+const Label = styled.label`
+  font-size: 1em;
+  font-weight: bold;
+  color: #FF7A63;
+`;
+
+const TextInput = styled.input`
+  width: 100%;
+  font-size: .9em;
+  padding: .7em;
+  border: ${({ hasError }) => (
+    hasError ? '1px solid #f00' : '1px solid #D8D8D8'
+  )};
+  margin-bottom: .3em;
+
+  :focus {
+    outline: none;
+  }
+
+  ::placeholder {
+    font-size: .8em;
+    color: ${({ hasError }) => (
+    hasError ? '#f00' : '#C0C0C0'
+  )};
+  }
+`;
+
+export default function PostFormExerciseName() {
+  const postFormStore = usePostFormStore();
+
+  const {
+    gameExercise,
+    formErrors,
+  } = postFormStore;
+
+  const handleChangeGameExercise = (event) => {
+    const { value } = event.target;
+    postFormStore.changeGameExercise(value);
+  };
+
+  return (
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
+      <TitleAndError>
+        <Label htmlFor="input-game-exercise">
+          종목
+        </Label>
+      </TitleAndError>
+      <TextInput
+        id="input-game-exercise"
+        type="text"
+        placeholder={(
+          formErrors.BLANK_GAME_EXERCISE ? (
+            formErrors.BLANK_GAME_EXERCISE
+          ) : '종목 이름을 입력해주세요.'
+        )}
+        value={gameExercise}
+        onChange={(event) => handleChangeGameExercise(event)}
+        hasError={formErrors.BLANK_GAME_EXERCISE}
+      />
+    </ComponentSectionContainer>
+  );
+}

--- a/src/components/PostFormPlace.jsx
+++ b/src/components/PostFormPlace.jsx
@@ -1,0 +1,88 @@
+import styled from 'styled-components';
+import usePostFormStore from '../hooks/usePostFormStore';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
+
+const TitleAndError = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+`;
+
+const Label = styled.label`
+  font-size: 1em;
+  font-weight: bold;
+  color: #FF7A63;
+`;
+
+const Error = styled.p`
+  font-size: .8em;
+  color: #f00;
+`;
+
+const TextInput = styled.input`
+  width: 100%;
+  font-size: .9em;
+  padding: .7em;
+  border: ${({ hasError }) => (
+    hasError ? '1px solid #f00' : '1px solid #D8D8D8'
+  )};
+  margin-bottom: .3em;
+
+  :focus {
+    outline: none;
+  }
+
+  ::placeholder {
+    font-size: .8em;
+    color: ${({ hasError }) => (
+    hasError ? '#f00' : '#C0C0C0'
+  )};
+  }
+`;
+
+export default function PostFormPlace() {
+  const postFormStore = usePostFormStore();
+
+  const {
+    placeName,
+    formErrors,
+    serverError,
+  } = postFormStore;
+
+  const handleChangePlaceName = (event) => {
+    const { value } = event.target;
+    postFormStore.changePlaceName(value);
+  };
+
+  return (
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
+      <TitleAndError>
+        <Label htmlFor="input-place-name">
+          장소
+        </Label>
+        {serverError && (
+          <Error>등록되지 않은 장소입니다.</Error>
+        )}
+      </TitleAndError>
+      <TextInput
+        id="input-place-name"
+        type="text"
+        placeholder={(
+          formErrors.BLANK_PLACE_NAME ? (
+            formErrors.BLANK_PLACE_NAME
+          ) : '장소 이름을 입력해주세요.'
+        )}
+        value={placeName}
+        onChange={handleChangePlaceName}
+        hasError={(
+          formErrors.BLANK_PLACE_NAME
+              || serverError
+        )}
+      />
+    </ComponentSectionContainer>
+  );
+}

--- a/src/components/PostFormTargetMemberCount.jsx
+++ b/src/components/PostFormTargetMemberCount.jsx
@@ -1,0 +1,76 @@
+import styled from 'styled-components';
+import usePostFormStore from '../hooks/usePostFormStore';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
+
+const TitleAndError = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+`;
+
+const Label = styled.label`
+  font-size: 1em;
+  font-weight: bold;
+  color: #FF7A63;
+`;
+
+const TextInput = styled.input`
+  width: 100%;
+  font-size: .9em;
+  padding: .7em;
+  border: ${({ hasError }) => (
+    hasError ? '1px solid #f00' : '1px solid #D8D8D8'
+  )};
+  margin-bottom: .3em;
+
+  :focus {
+    outline: none;
+  }
+
+  ::placeholder {
+    font-size: .8em;
+    color: ${({ hasError }) => (
+    hasError ? '#f00' : '#C0C0C0'
+  )};
+  }
+`;
+
+export default function PostFormTargetMemberCount() {
+  const postFormStore = usePostFormStore();
+
+  const {
+    gameTargetMemberCount,
+    formErrors,
+  } = postFormStore;
+
+  const handleChangeGameTargetMemberCount = (event) => {
+    const { value } = event.target;
+    postFormStore.changeGameTargetMemberCount(value);
+  };
+
+  return (
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
+      <TitleAndError>
+        <Label htmlFor="input-game-target-member-count">
+          모집 인원
+        </Label>
+      </TitleAndError>
+      <TextInput
+        id="input-game-target-member-count"
+        type="number"
+        placeholder={(
+          formErrors.NULL_GAME_TARGET_MEMBER_COUNT ? (
+            formErrors.NULL_GAME_TARGET_MEMBER_COUNT
+          ) : '운동 모집 인원 (2명 이상)'
+        )}
+        value={gameTargetMemberCount}
+        onChange={handleChangeGameTargetMemberCount}
+        hasError={formErrors.NULL_GAME_TARGET_MEMBER_COUNT}
+      />
+    </ComponentSectionContainer>
+  );
+}

--- a/src/components/PostFormTime.jsx
+++ b/src/components/PostFormTime.jsx
@@ -1,0 +1,278 @@
+import styled from 'styled-components';
+
+import usePostFormStore from '../hooks/usePostFormStore';
+
+import SelectTime from './SelectTime';
+
+const Container = styled.div`
+  
+`;
+
+const Time = styled.div`
+  margin-bottom: .5em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const AmPm = styled.div`
+  margin-right: .5em;
+
+  label {
+    margin-right: .5em;
+  }
+
+  input {
+    display: none;
+  }
+
+  span {
+    display: none;
+  }
+`;
+
+const AmButton = styled.button`
+  color: ${({ selectedState }) => (
+    selectedState === 'am'
+      ? '#fff'
+      : '#FF7A63'
+  )};
+  padding: .5em 1.25em;
+  border: ${({ selectedState }) => (
+    selectedState === 'am'
+      ? '1px solid transparent'
+      : '1px solid #CCC'
+  )};
+  border-radius: 5px;
+  margin-inline: .3em;
+  background-color: ${({ selectedState }) => (
+    selectedState === 'am'
+      ? '#FF7A63'
+      : '#fff'
+  )};
+
+  :hover {
+    color: #fff;
+    border-color: transparent;
+    background-color: #FF7A63;
+    cursor: pointer;
+  }
+
+  :active {
+    color: #fff;
+    border-color: transparent;
+    background-color: #090040;
+    cursor: pointer;
+  }
+`;
+
+const PmButton = styled.button`
+  color: ${({ selectedState }) => (
+    selectedState === 'pm'
+      ? '#fff'
+      : '#FF7A63'
+  )};
+  padding: .5em 1.25em;
+  border: ${({ selectedState }) => (
+    selectedState === 'pm'
+      ? '1px solid transparent'
+      : '1px solid #CCC'
+  )};
+  border-radius: 5px;
+  margin-inline: .3em;
+  background-color: ${({ selectedState }) => (
+    selectedState === 'pm'
+      ? '#FF7A63'
+      : '#fff'
+  )};
+
+  :hover {
+    color: #fff;
+    border-color: transparent;
+    background-color: #FF7A63;
+    cursor: pointer;
+  }
+
+  :active {
+    color: #fff;
+    border-color: transparent;
+    background-color: #090040;
+    cursor: pointer;
+  }
+`;
+
+const HourAndMinute = styled.div`
+  display: flex;
+
+  div {
+    margin-inline: .3em;
+  }
+`;
+
+export default function PostFormTime() {
+  const postFormStore = usePostFormStore();
+
+  const {
+    gameStartTimeAmPm,
+    gameStartHour,
+    gameStartMinute,
+    gameEndTimeAmPm,
+    gameEndHour,
+    gameEndMinute,
+  } = postFormStore;
+
+  const handleChangeGameStartTimeAmPm = (event) => {
+    const { value } = event.target;
+    postFormStore.changeGameStartTimeAmPm(value);
+  };
+
+  const handleChangeGameStartHour = (event) => {
+    const { value } = event.target;
+    postFormStore.changeGameStartHour(value);
+  };
+
+  const handleChangeGameStartMinute = (event) => {
+    const { value } = event.target;
+    postFormStore.changeGameStartMinute(value);
+  };
+
+  const handleChangeGameEndTimeAmPm = (event) => {
+    const { value } = event.target;
+    postFormStore.changeGameEndTimeAmPm(value);
+  };
+
+  const handleChangeGameEndHour = (event) => {
+    const { value } = event.target;
+    postFormStore.changeGameEndHour(value);
+  };
+
+  const handleChangeGameEndMinute = (event) => {
+    const { value } = event.target;
+    postFormStore.changeGameEndMinute(value);
+  };
+
+  return (
+    <Container>
+      <Time>
+        <AmPm>
+          <input
+            id="input-game-start-time-am"
+            type="radio"
+            name="start-time-am-pm"
+            value="am"
+            onChange={handleChangeGameStartTimeAmPm}
+          />
+          <label htmlFor="input-game-start-time-am">
+            <AmButton
+              className="input-game-start-time-am"
+              selectedState={gameStartTimeAmPm}
+              type="button"
+              value="am"
+              onClick={handleChangeGameStartTimeAmPm}
+            >
+              <span>시작 </span>
+              오전
+            </AmButton>
+          </label>
+          <input
+            id="input-game-start-time-pm"
+            type="radio"
+            name="start-time-am-pm"
+            value="pm"
+            onChange={handleChangeGameStartTimeAmPm}
+          />
+          <label htmlFor="input-game-start-time-pm">
+            <PmButton
+              className="input-game-start-time-pm"
+              selectedState={gameStartTimeAmPm}
+              type="button"
+              value="pm"
+              onClick={handleChangeGameStartTimeAmPm}
+            >
+              <span>시작 </span>
+              오후
+            </PmButton>
+          </label>
+        </AmPm>
+        <HourAndMinute>
+          <SelectTime
+            id="input-game-start-hour"
+            onChange={handleChangeGameStartHour}
+            type="start"
+            time="hour"
+            value={gameStartHour}
+          />
+          <p>:</p>
+          <SelectTime
+            id="input-game-start-minute"
+            onChange={handleChangeGameStartMinute}
+            type="start"
+            time="minute"
+            value={gameStartMinute}
+          />
+        </HourAndMinute>
+        <p>부터</p>
+      </Time>
+      <Time>
+        <AmPm>
+          <input
+            id="input-game-end-time-am"
+            type="radio"
+            name="end-time-am-pm"
+            value="am"
+            onChange={handleChangeGameEndTimeAmPm}
+          />
+          <label htmlFor="input-game-end-time-am">
+            <AmButton
+              className="input-game-end-time-am"
+              selectedState={gameEndTimeAmPm}
+              type="button"
+              value="am"
+              onClick={handleChangeGameEndTimeAmPm}
+            >
+              <span>종료 </span>
+              오전
+            </AmButton>
+          </label>
+          <input
+            id="input-game-end-time-pm"
+            type="radio"
+            name="end-time-am-pm"
+            value="pm"
+            onChange={handleChangeGameEndTimeAmPm}
+          />
+          <label htmlFor="input-game-end-time-pm">
+            <PmButton
+              className="input-game-end-time-pm"
+              selectedState={gameEndTimeAmPm}
+              type="button"
+              value="pm"
+              onClick={handleChangeGameEndTimeAmPm}
+            >
+              <span>종료 </span>
+              오후
+            </PmButton>
+          </label>
+        </AmPm>
+        <HourAndMinute>
+          <SelectTime
+            id="input-game-end-hour"
+            onChange={handleChangeGameEndHour}
+            type="end"
+            time="hour"
+            value={gameEndHour}
+          />
+          <p>:</p>
+          <SelectTime
+            id="input-game-end-minute"
+            onChange={handleChangeGameEndMinute}
+            type="end"
+            time="minute"
+            value={gameEndMinute}
+          />
+          <p>까지</p>
+        </HourAndMinute>
+      </Time>
+    </Container>
+  );
+}

--- a/src/components/PostGame.jsx
+++ b/src/components/PostGame.jsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 
-import Container from './ui/ComponentSectionContainer';
+import useGameStore from '../hooks/useGameStore';
+import usePlaceStore from '../hooks/usePlaceStore';
+import usePostStore from '../hooks/usePostStore';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
 
 const ExerciseName = styled.p`
   font-size: 1em;
@@ -42,28 +46,31 @@ const Hits = styled.p`
   
 `;
 
-export default function PostGame({
-  name,
-  date,
-  place,
-  currentMemberCount,
-  targetMemberCount,
-  hits,
-}) {
+export default function PostGame() {
+  const postStore = usePostStore();
+  const gameStore = useGameStore();
+  const placeStore = usePlaceStore();
+
+  const { post } = postStore;
+  const { game } = gameStore;
+  const { place } = placeStore;
+
   return (
-    <Container>
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
       <ExerciseName>
-        {name}
+        {game.type}
       </ExerciseName>
       <DateAndPlace>
-        <p>{date}</p>
-        <p>{place}</p>
+        <p>{game.date}</p>
+        <p>{place.name}</p>
       </DateAndPlace>
       <MembersCreatedAtAndHits>
         <Members>
-          {currentMemberCount}
+          {game.currentMemberCount}
           /
-          {targetMemberCount}
+          {game.targetMemberCount}
           명 참가 중
         </Members>
         <CreatedAtAndHits>
@@ -72,12 +79,12 @@ export default function PostGame({
             작성시간
           </CreatedAt>
           <Hits>
-            {hits}
+            {post.hits}
             {' '}
             조회
           </Hits>
         </CreatedAtAndHits>
       </MembersCreatedAtAndHits>
-    </Container>
+    </ComponentSectionContainer>
   );
 }

--- a/src/components/PostGameMembers.jsx
+++ b/src/components/PostGameMembers.jsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 
-import Container from './ui/ComponentSectionContainer';
+import usePostStore from '../hooks/usePostStore';
+import useGameStore from '../hooks/useGameStore';
+import useRegisterStore from '../hooks/useRegisterStore';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
 
 const Title = styled.p`
   font-size: 1em;
@@ -20,8 +24,10 @@ const MemberProfile = styled.div`
   margin-right: 2em;
 
   img {
+    height: 12em;
     width: 12em;
     border-radius: 100%;
+    object-fit: cover;
   }
 `;
 
@@ -91,47 +97,55 @@ const EnterChatRoomButton = styled.button`
   }
 `;
 
-export default function PostGameMembers({
-  members,
-  isAuthor,
-  registerStatus,
-}) {
+export default function PostGameMembers() {
+  const postStore = usePostStore();
+  const gameStore = useGameStore();
+  const registerStore = useRegisterStore();
+
+  const { post } = postStore;
+  const { game } = gameStore;
+  const { members } = registerStore;
+
   if (members.length === 0) {
     return (
-      <Container>
+      <ComponentSectionContainer
+        backgroundColor="#FFF"
+      >
         <p>참가자가 없습니다.</p>
-      </Container>
+      </ComponentSectionContainer>
     );
   }
 
   return (
-    <Container>
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
       <Title>
         참가자 정보
       </Title>
       <ul>
         {members.map((member) => (
-          <Member key={member.id}>
+          <Member key={member.registerId}>
             <MemberProfile>
               <img
-                src={member.profileImageUrl}
+                src={member.userInformation.profileImageUrl}
                 alt="사용자 프로필 이미지"
               />
             </MemberProfile>
             <MemberInformation>
               <NameAndGender>
-                <p>{member.name}</p>
-                <p>{member.gender}</p>
+                <p>{member.userInformation.name}</p>
+                <p>{member.userInformation.gender}</p>
               </NameAndGender>
               <PhoneNumber>
-                <p>{member.phoneNumber}</p>
+                <p>{member.userInformation.phoneNumber}</p>
               </PhoneNumber>
             </MemberInformation>
             <MemberScoreAndSeeProfile>
               <Score>
                 평점:
                 {' '}
-                {member.mannerScore}
+                {member.userInformation.mannerScore}
               </Score>
               <SeeProfile>
                 프로필 확인하기
@@ -140,7 +154,7 @@ export default function PostGameMembers({
           </Member>
         ))}
       </ul>
-      {isAuthor || registerStatus === 'accepted' ? (
+      {post.isAuthor || game.registerStatus === 'accepted' ? (
         <EnterChatRoomButton
           type="button"
         >
@@ -149,6 +163,6 @@ export default function PostGameMembers({
       ) : (
         null
       )}
-    </Container>
+    </ComponentSectionContainer>
   );
 }

--- a/src/components/PostImages.jsx
+++ b/src/components/PostImages.jsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
-
-import temporaryImageUrl from './assets/images/TemporaryImage.png';
+import usePostStore from '../hooks/usePostStore';
 
 const Container = styled.section`
 `;
@@ -21,13 +20,17 @@ const ImageList = styled.ul`
 `;
 
 const Image = styled.img`
-  width: 3em;
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
 `;
 
-export default function PostImages({
-  imageUrls,
-}) {
-  if (imageUrls.length === 0) {
+export default function PostImages() {
+  const postStore = usePostStore();
+
+  const { post } = postStore;
+
+  if (post.imageUrls.length === 0) {
     return (
       null
     );
@@ -37,7 +40,7 @@ export default function PostImages({
     <Container>
       <ImageList>
         {/* TODO: 같은 url의 이미지 여러 개가 전달될 가능성이 있는가? */}
-        {imageUrls.map((imageUrl, index) => (
+        {post.imageUrls.map((imageUrl, index) => (
           <li key={imageUrl}>
             <Image
               src={imageUrl}

--- a/src/components/PostLoginGuidance.jsx
+++ b/src/components/PostLoginGuidance.jsx
@@ -1,0 +1,48 @@
+/* eslint-disable no-nested-ternary */
+
+import styled from 'styled-components';
+
+import Button from './ui/PrimaryButton';
+
+const Container = styled.section`
+  font-size: .9em;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1em;
+  padding: 1.25em;
+  border-radius: 5px;
+  background-color: #fff;
+`;
+
+export default function PostLoginGuidance({
+  navigateLogin,
+  navigateSelectTrialAccount,
+}) {
+  const onClickLogin = () => {
+    navigateLogin();
+  };
+
+  const onClickSelectTrialAccount = () => {
+    navigateSelectTrialAccount();
+  };
+
+  return (
+    <Container>
+      <p>참가를 신청하려면 로그인이 필요합니다.</p>
+      <Button
+        type="button"
+        onClick={onClickLogin}
+      >
+        로그인하기
+      </Button>
+      <Button
+        type="button"
+        onClick={onClickSelectTrialAccount}
+      >
+        체험 계정 선택하기
+      </Button>
+    </Container>
+  );
+}

--- a/src/components/PostPlace.jsx
+++ b/src/components/PostPlace.jsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
-import Container from './ui/ComponentSectionContainer';
+import usePlaceStore from '../hooks/usePlaceStore';
+
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
 
 const PlaceInformation = styled.div`
   
@@ -44,11 +46,15 @@ const Map = styled.iframe`
   background-color: #D9D9D9;
 `;
 
-export default function PostPlace({
-  place,
-}) {
+export default function PostPlace() {
+  const placeStore = usePlaceStore();
+
+  const { place } = placeStore;
+
   return (
-    <Container>
+    <ComponentSectionContainer
+      backgroundColor="#FFF"
+    >
       <GridWrapper>
         <PlaceInformation>
           <Title>
@@ -68,6 +74,6 @@ export default function PostPlace({
           <Map />
         </PlaceMap>
       </GridWrapper>
-    </Container>
+    </ComponentSectionContainer>
   );
 }

--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -1,110 +1,15 @@
 /* eslint-disable no-nested-ternary */
 
-import { useState } from 'react';
 import styled from 'styled-components';
+import { useEffect } from 'react';
+import usePostStore from '../hooks/usePostStore';
 
+import ComponentSectionContainer from './ui/ComponentSectionContainer';
 import PostsContent from './PostsContent';
-import Container from './ui/ComponentScreenContainer';
 import SecondaryButton from './ui/SecondaryButton';
 
-const SearchAndSettingToggleButton = styled.div`
-  width: 100%;
-  margin-bottom: 1em;
-  display: flex;
-  justify-content: space-between;
-`;
-
-const Search = styled.div`
-  label {
-    display: none;
-  }
-
-  input {
-    width: 13em;
-    padding: .5em;
-    border: 1px solid #CCC;
-    margin-right: .6em;
-  }
-
-  input::placeholder {
-    color: #CCC;
-  }
-
-  button {
-    padding: .5em 1.25em;
-    border: 1px solid #CCC;
-    border-radius: 5px;
-    background-color: #fff;
-  }
-`;
-
-const ToggleButton = styled.button`
-  color: ${({ toggledState }) => (
-    toggledState ? '#fff' : '#FF7A63'
-  )};
-  padding: .5em 1.25em;
-  border: ${({ toggledState }) => (
-    toggledState ? '1px solid transparent' : '1px solid #CCC'
-  )};
-  border-radius: 5px;
-  margin-inline: .3em;
-  background-color: ${({ toggledState }) => (
-    toggledState ? '#FF7A63' : '#fff'
-  )};
-
-  :hover {
-    color: #fff;
-    border-color: transparent;
-    background-color: #FF7A63;
-  }
-
-  :active {
-    color: #fff;
-    border-color: transparent;
-    background-color: #090040;
-  }
-`;
-
-const SettingToggleButtons = styled.div`
-  
-`;
-
-const SearchSettingSection = styled.section`
-  width: 100%;
-  padding-block: 1em;
-  margin-bottom: 1em;
-  border: 1px solid #CCC;
-  background-color: #fff;
-
-  button {
-    padding-inline: 1.75em;
-  }
-
-  button:first-child {
-    margin-left: 1em;
-  }
-`;
-
-const FilterSettingSection = styled.section`
-  width: 100%;
-  padding-block: 1em;
-  margin-bottom: 1em;
-  border: 1px solid #CCC;
-  background-color: #fff;
-
-  button:first-child {
-    margin-left: 1em;
-  }
-`;
-
-const PostsSection = styled.section`
-  width: 100%;
-  border: 1px solid #CCC;
-  background-color: #FFFFFFBB;
-`;
-
 const SelectListOrMap = styled.nav`
-  margin: 1em 1em 1.5em;
+  padding-bottom: .5em;
   display: flex;
   align-items: center;
   
@@ -124,7 +29,7 @@ const ListButton = styled.button`
 `;
 
 const PostsList = styled.section`
-  margin: 1em 1em 7em;
+  margin-bottom: 7em;
 `;
 
 const Thumbnails = styled.ul`
@@ -139,210 +44,66 @@ const Thumbnail = styled.li`
 `;
 
 export default function Posts({
-  loggedIn,
-  searchSetting,
-  filterSetting,
-  toggleSearchSetting,
-  toggleFilterSetting,
-  posts,
   navigatePost,
-  postsServerError,
 }) {
-  // TODO: 검색 조건 상태, 조회 방식 설정 상태는 별도의 FormStore를 생성해 저장하는 방식으로 리팩터링
-  //   클릭된 버튼의 상태를 검사해 클릭된 버튼의 경우 hover 시의 색상을 항상 유지
+  const postStore = usePostStore();
 
-  const [searchKeyword, changeSearchKeyword] = useState('');
+  useEffect(() => {
+    postStore.fetchPosts();
+  }, []);
 
-  // TODO: toggledState 상태는 추후 검색을 위한 별도의 Store에서 관리하도록 하고,
-  //   임시로 설정한 setState 함수들도 모두 Store에서 처리하도록 해야 함
+  const {
+    posts,
+    postsServerError,
+  } = postStore;
 
-  const [exerciseSelection, toggleExerciseSelection] = useState(false);
-  const [placeSelection, togglePlaceSelection] = useState(false);
-  const [authorSelection, toggleAuthorSelection] = useState(false);
-  const [memberSelection, toggleMemberSelection] = useState(false);
-  const [applicantSelection, toggleApplicantSelection] = useState(false);
-
-  const [registeredSelection, setRegisteredSelection] = useState(false);
-  const [writtenSelection, setWrittenSelection] = useState(false);
-
-  const onClickPost = (postId) => {
+  const handleClickPost = (postId) => {
     navigatePost(postId);
   };
 
-  const resetToggleState = () => {
-    toggleExerciseSelection(false);
-    togglePlaceSelection(false);
-    toggleAuthorSelection(false);
-    toggleMemberSelection(false);
-    toggleApplicantSelection(false);
-  };
-
-  const resetRegisteredOrWritten = () => {
-    setRegisteredSelection(false);
-    setWrittenSelection(false);
-  };
-
-  // TODO: 컴포넌트들을 여러 개의 독립적인 컴포넌트들로 분리
-
   return (
-    <Container>
-      <SearchAndSettingToggleButton>
-        <Search>
-          <label htmlFor="post-keyword">
-            검색어
-          </label>
-          <input
-            id="post-keyword"
-            type="text"
-            placeholder="검색어 입력"
-            value={searchKeyword}
-            onChange={(event) => changeSearchKeyword(event.target.value)}
-          />
-          <button
-            type="button"
-          >
-            검색
-          </button>
-        </Search>
-        <SettingToggleButtons>
-          <ToggleButton
-            toggledState={searchSetting}
-            type="button"
-            onClick={toggleSearchSetting}
-          >
-            검색조건 설정
-          </ToggleButton>
-          <ToggleButton
-            toggledState={filterSetting}
-            type="button"
-            onClick={toggleFilterSetting}
-          >
-            조회방식 설정
-          </ToggleButton>
-        </SettingToggleButtons>
-      </SearchAndSettingToggleButton>
-      {searchSetting && (
-        <SearchSettingSection>
-          <ToggleButton
-            toggledState={exerciseSelection}
-            type="button"
-            onClick={() => {
-              resetRegisteredOrWritten();
-              toggleExerciseSelection(!exerciseSelection);
-            }}
-          >
-            종목
-          </ToggleButton>
-          <ToggleButton
-            toggledState={placeSelection}
-            type="button"
-            onClick={() => {
-              resetRegisteredOrWritten();
-              togglePlaceSelection(!placeSelection);
-            }}
-          >
-            장소
-          </ToggleButton>
-          <ToggleButton
-            toggledState={authorSelection}
-            type="button"
-            onClick={() => {
-              resetRegisteredOrWritten();
-              toggleAuthorSelection(!authorSelection);
-            }}
-          >
-            작성자
-          </ToggleButton>
-          <ToggleButton
-            toggledState={memberSelection}
-            type="button"
-            onClick={() => {
-              resetRegisteredOrWritten();
-              toggleMemberSelection(!memberSelection);
-            }}
-          >
-            참가자
-          </ToggleButton>
-          <ToggleButton
-            toggledState={applicantSelection}
-            type="button"
-            onClick={() => {
-              resetRegisteredOrWritten();
-              toggleApplicantSelection(!applicantSelection);
-            }}
-          >
-            신청자
-          </ToggleButton>
-        </SearchSettingSection>
-      )}
-      {filterSetting && (
-        <FilterSettingSection>
-          <ToggleButton
-            toggledState={registeredSelection}
-            type="button"
-            onClick={() => {
-              resetToggleState();
-              setRegisteredSelection(true);
-              setWrittenSelection(false);
-            }}
-          >
-            내가 참가하는 운동
-          </ToggleButton>
-          <ToggleButton
-            toggledState={writtenSelection}
-            type="button"
-            onClick={() => {
-              resetToggleState();
-              setRegisteredSelection(false);
-              setWrittenSelection(true);
-            }}
-          >
-            내가 모집하는 운동
-          </ToggleButton>
-        </FilterSettingSection>
-      )}
-      <PostsSection>
-        <SelectListOrMap>
-          <p>조회 방식 선택</p>
-          <ListButton
-            type="button"
-          >
-            리스트
-          </ListButton>
-          <SecondaryButton
-            type="button"
-          >
-            지도
-          </SecondaryButton>
-        </SelectListOrMap>
-        <PostsList>
-          {posts.length === 0 ? (
-            <p>등록된 게시물이 존재하지 않습니다.</p>
-          ) : postsServerError ? (
-            <p>{postsServerError}</p>
-          ) : (
-            <Thumbnails>
-              {posts.map((post) => (
-                <Thumbnail key={post.id}>
-                  <PostsContent
-                    loggedIn={loggedIn}
-                    imageUrl={post.thumbnailImageUrl}
-                    hits={post.hits}
-                    isAuthor={post.isAuthor}
-                    type={post.game.type}
-                    date={post.game.date}
-                    place={post.place.name}
-                    currentMemberCount={post.game.currentMemberCount}
-                    targetMemberCount={post.game.targetMemberCount}
-                    registerStatus={post.game.registerStatus}
-                    onClickPost={() => onClickPost(post.id)}
-                  />
-                </Thumbnail>
-              ))}
-            </Thumbnails>
-          )}
-        </PostsList>
-      </PostsSection>
-    </Container>
+    <ComponentSectionContainer
+      backgroundColor="#FFFFFFBB"
+    >
+      <SelectListOrMap>
+        <p>조회 방식 선택</p>
+        <ListButton
+          type="button"
+        >
+          리스트
+        </ListButton>
+        <SecondaryButton
+          type="button"
+        >
+          지도
+        </SecondaryButton>
+      </SelectListOrMap>
+      <PostsList>
+        {posts.length === 0 ? (
+          <p>등록된 게시물이 존재하지 않습니다.</p>
+        ) : postsServerError ? (
+          <p>{postsServerError}</p>
+        ) : (
+          <Thumbnails>
+            {posts.map((post) => (
+              <Thumbnail key={post.id}>
+                <PostsContent
+                  imageUrl={post.thumbnailImageUrl}
+                  hits={post.hits}
+                  isAuthor={post.isAuthor}
+                  type={post.game.type}
+                  date={post.game.date}
+                  place={post.place.name}
+                  currentMemberCount={post.game.currentMemberCount}
+                  targetMemberCount={post.game.targetMemberCount}
+                  registerStatus={post.game.registerStatus}
+                  onClickPost={() => handleClickPost(post.id)}
+                />
+              </Thumbnail>
+            ))}
+          </Thumbnails>
+        )}
+      </PostsList>
+    </ComponentSectionContainer>
   );
 }

--- a/src/components/PostsContent.jsx
+++ b/src/components/PostsContent.jsx
@@ -1,6 +1,12 @@
 /* eslint-disable no-nested-ternary */
 
+import { useEffect } from 'react';
+
 import styled from 'styled-components';
+
+import { useLocalStorage } from 'usehooks-ts';
+
+import { postApiService } from '../services/PostApiService';
 
 const Container = styled.button`
   font-size: 1em;
@@ -20,7 +26,9 @@ const Left = styled.div`
   background-color: #D9D9D9; 
 
   img {
-    height: 25%;
+    height: 7em;
+    width: 10em;
+    object-fit: cover;
   }
 `;
 
@@ -90,7 +98,6 @@ const RegisterStatus = styled.div`
 `;
 
 export default function PostsContent({
-  loggedIn,
   imageUrl,
   hits,
   isAuthor,
@@ -102,6 +109,13 @@ export default function PostsContent({
   registerStatus,
   onClickPost,
 }) {
+  const [accessToken] = useLocalStorage('accessToken', '');
+  const loggedIn = accessToken !== '';
+
+  useEffect(() => {
+    postApiService.setAccessToken(accessToken);
+  }, [accessToken]);
+
   const handleClickPostButton = () => {
     onClickPost();
   };
@@ -144,9 +158,9 @@ export default function PostsContent({
             {' '}
             조회
           </p>
-          <p>
+          {/* <p>
             1시간 전
-          </p>
+          </p> */}
         </CreatedAtAndHits>
         <RegisterStatus>
           {loggedIn ? (

--- a/src/components/PostsSearchAndSettings.jsx
+++ b/src/components/PostsSearchAndSettings.jsx
@@ -1,0 +1,260 @@
+import { useEffect } from 'react';
+import { useState } from 'react';
+import styled from 'styled-components';
+import usePostStore from '../hooks/usePostStore';
+
+const Container = styled.section`
+  width: 100%;
+  margin-bottom: 1em;
+`;
+
+const SearchAndSettingToggleButton = styled.div`
+  width: 100%;
+  margin-bottom: ${({ settingSectionOpened }) => (
+    settingSectionOpened ? '1em' : '0'
+  )};
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Search = styled.div`
+  label {
+    display: none;
+  }
+
+  input {
+    width: 13em;
+    padding: .5em;
+    border: 1px solid #CCC;
+    margin-right: .6em;
+  }
+
+  input::placeholder {
+    color: #CCC;
+  }
+
+  button {
+    padding: .5em 1.25em;
+    border: 1px solid #CCC;
+    border-radius: 5px;
+    background-color: #fff;
+  }
+`;
+
+const ToggleButton = styled.button`
+  color: ${({ toggledState }) => (
+    toggledState ? '#fff' : '#FF7A63'
+  )};
+  padding: .5em 1.25em;
+  border: ${({ toggledState }) => (
+    toggledState ? '1px solid transparent' : '1px solid #CCC'
+  )};
+  border-radius: 5px;
+  margin-inline: .3em;
+  background-color: ${({ toggledState }) => (
+    toggledState ? '#FF7A63' : '#fff'
+  )};
+
+  :hover {
+    color: #fff;
+    border-color: transparent;
+    background-color: #FF7A63;
+  }
+
+  :active {
+    color: #fff;
+    border-color: transparent;
+    background-color: #090040;
+  }
+`;
+
+const SettingToggleButtons = styled.div`
+  
+`;
+
+const SearchSettingSection = styled.section`
+  width: 100%;
+  padding-block: 1em;
+  border: 1px solid #CCC;
+  background-color: #fff;
+
+  button {
+    padding-inline: 1.75em;
+  }
+
+  button:first-child {
+    margin-left: 1em;
+  }
+`;
+
+const FilterSettingSection = styled.section`
+  width: 100%;
+  padding-block: 1em;
+  border: 1px solid #CCC;
+  background-color: #fff;
+
+  button:first-child {
+    margin-left: 1em;
+  }
+`;
+
+export default function PostsSearchAndSettings() {
+  const [searchSetting, toggleSearchSetting] = useState(false);
+  const [filterSetting, toggleFilterSetting] = useState(false);
+
+  const [searchKeyword, changeSearchKeyword] = useState('');
+
+  const postStore = usePostStore();
+
+  useEffect(() => {
+    postStore.resetSearchConditionState();
+    postStore.resetLookUpConditionState();
+  }, []);
+
+  const {
+    exerciseSelection,
+    placeSelection,
+    authorSelection,
+    memberSelection,
+    applicantSelection,
+    registeredSelection,
+    writtenSelection,
+  } = postStore;
+
+  const handleClickToggleSearchSetting = () => {
+    toggleSearchSetting(!searchSetting);
+    toggleFilterSetting(false);
+  };
+
+  const handleClickToggleFilterSetting = () => {
+    toggleSearchSetting(false);
+    toggleFilterSetting(!filterSetting);
+  };
+
+  const handleClickExerciseButton = () => {
+    postStore.changeExerciseSelection();
+  };
+
+  const handleClickPlaceButton = () => {
+    postStore.changePlaceSelection();
+  };
+
+  const handleClickAuthorButton = () => {
+    postStore.changeAuthorSelection();
+  };
+
+  const handleClickMemberButton = () => {
+    postStore.changeMemberSelection();
+  };
+
+  const handleClickApplicantButton = () => {
+    postStore.changeApplicantSelection();
+  };
+
+  const handleClickRegisteredButton = () => {
+    postStore.setRegisteredSelection();
+  };
+
+  const handleClickWrittenButton = () => {
+    postStore.setWrittenSelection();
+  };
+
+  return (
+    <Container>
+      <SearchAndSettingToggleButton
+        settingSectionOpened={searchSetting || filterSetting}
+      >
+        <Search>
+          <label htmlFor="post-keyword">
+            검색어
+          </label>
+          <input
+            id="post-keyword"
+            type="text"
+            placeholder="검색어 입력"
+            value={searchKeyword}
+            onChange={(event) => changeSearchKeyword(event.target.value)}
+          />
+          <button
+            type="button"
+          >
+            검색
+          </button>
+        </Search>
+        <SettingToggleButtons>
+          <ToggleButton
+            toggledState={searchSetting}
+            type="button"
+            onClick={handleClickToggleSearchSetting}
+          >
+            검색조건 설정
+          </ToggleButton>
+          <ToggleButton
+            toggledState={filterSetting}
+            type="button"
+            onClick={handleClickToggleFilterSetting}
+          >
+            조회방식 설정
+          </ToggleButton>
+        </SettingToggleButtons>
+      </SearchAndSettingToggleButton>
+      {searchSetting && (
+        <SearchSettingSection>
+          <ToggleButton
+            toggledState={exerciseSelection}
+            type="button"
+            onClick={handleClickExerciseButton}
+          >
+            종목
+          </ToggleButton>
+          <ToggleButton
+            toggledState={placeSelection}
+            type="button"
+            onClick={handleClickPlaceButton}
+          >
+            장소
+          </ToggleButton>
+          <ToggleButton
+            toggledState={authorSelection}
+            type="button"
+            onClick={handleClickAuthorButton}
+          >
+            작성자
+          </ToggleButton>
+          <ToggleButton
+            toggledState={memberSelection}
+            type="button"
+            onClick={handleClickMemberButton}
+          >
+            참가자
+          </ToggleButton>
+          <ToggleButton
+            toggledState={applicantSelection}
+            type="button"
+            onClick={handleClickApplicantButton}
+          >
+            신청자
+          </ToggleButton>
+        </SearchSettingSection>
+      )}
+      {filterSetting && (
+        <FilterSettingSection>
+          <ToggleButton
+            toggledState={registeredSelection}
+            type="button"
+            onClick={handleClickRegisteredButton}
+          >
+            내가 참가하는 운동
+          </ToggleButton>
+          <ToggleButton
+            toggledState={writtenSelection}
+            type="button"
+            onClick={handleClickWrittenButton}
+          >
+            내가 모집하는 운동
+          </ToggleButton>
+        </FilterSettingSection>
+      )}
+    </Container>
+  );
+}

--- a/src/components/ui/ComponentSectionContainer.jsx
+++ b/src/components/ui/ComponentSectionContainer.jsx
@@ -5,7 +5,7 @@ const ComponentSectionContainer = styled.article`
   padding: 1em;
   border: 1px solid #ccc;
   margin-bottom: 1em;
-  background-color: #fff;
+  background-color: ${(props) => props.backgroundColor};
 `;
 
 export default ComponentSectionContainer;

--- a/src/pages/NoticesPage.jsx
+++ b/src/pages/NoticesPage.jsx
@@ -1,10 +1,7 @@
 /* eslint-disable no-nested-ternary */
 
-import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useLocalStorage } from 'usehooks-ts';
-
-import useNoticeStore from '../hooks/useNoticeStore';
 
 import Notices from '../components/Notices';
 
@@ -27,93 +24,13 @@ export default function NoticesPage() {
     navigate('/login');
   };
 
-  const noticeStore = useNoticeStore();
-
-  useEffect(() => {
-    noticeStore.closeSelectNoticeState();
-  }, []);
-
-  useEffect(() => {
-    if (!loggedIn) {
-      navigateLogin();
-    }
-    noticeStore.fetchNotices();
-  }, [accessToken]);
-
-  const {
-    noticesAll,
-    noticesUnread,
-    noticeStateToShow,
-    noticesDetailState,
-    selectNoticeState,
-    noticesSelectedState,
-  } = noticeStore;
-
-  const notices = noticeStateToShow === 'all'
-    ? noticesAll
-    : noticesUnread;
-
-  const showAll = async () => {
-    await noticeStore.showAll();
-  };
-
-  const showUnreadOnly = async () => {
-    await noticeStore.showUnreadOnly();
-  };
-
-  const showNoticeDetail = async ({ targetIndex, targetId }) => {
-    await noticeStore.showNoticeDetail(targetIndex);
-    await noticeStore.readNotice(targetId);
-  };
-
-  const closeNoticeDetail = (targetIndex) => {
-    noticeStore.closeNoticeDetail(targetIndex);
-  };
-
-  const toggleSelectNoticeState = () => {
-    noticeStore.toggleSelectNoticeState();
-  };
-
-  const selectNotice = ({ targetIndex, targetId }) => {
-    noticeStore.selectNotice({ targetIndex, targetId });
-  };
-
-  const selectAllNotices = () => {
-    noticeStore.selectAllNotices();
-  };
-
-  const deselectAllNotices = () => {
-    noticeStore.deselectAllNotices();
-  };
-
-  const readSelectedNotices = async () => {
-    await noticeStore.readSelectedNotices();
-    await noticeStore.fetchNotices();
-  };
-
-  const deleteSelectedNotices = async () => {
-    await noticeStore.deleteSelectedNotices();
-    await noticeStore.fetchNotices();
-  };
+  if (!loggedIn) {
+    navigateLogin();
+  }
 
   return (
     <Notices
       navigateBackward={navigateBackward}
-      notices={notices}
-      noticeStateToShow={noticeStateToShow}
-      showAll={showAll}
-      showUnreadOnly={showUnreadOnly}
-      noticesDetailState={noticesDetailState}
-      showNoticeDetail={showNoticeDetail}
-      closeNoticeDetail={closeNoticeDetail}
-      selectNoticeState={selectNoticeState}
-      toggleSelectNoticeState={toggleSelectNoticeState}
-      noticesSelectedState={noticesSelectedState}
-      selectNotice={selectNotice}
-      selectAllNotices={selectAllNotices}
-      deselectAllNotices={deselectAllNotices}
-      readSelectedNotices={readSelectedNotices}
-      deleteSelectedNotices={deleteSelectedNotices}
     />
   );
 }

--- a/src/pages/PostFormPage.jsx
+++ b/src/pages/PostFormPage.jsx
@@ -1,15 +1,8 @@
-import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import ModalReconfirm from '../components/ModalReconfirm';
+
 import PostForm from '../components/PostForm';
 
-import usePostFormStore from '../hooks/usePostFormStore';
-
 export default function PostFormPage() {
-  const [action, setAction] = useState(null);
-  const [actionMessage, setActionMessage] = useState('');
-  const [reconfirmModalState, setReconfirmModalState] = useState(false);
-
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -17,156 +10,22 @@ export default function PostFormPage() {
     ? location.state.previousPath
     : null;
 
-  const postFormStore = usePostFormStore();
-
-  useEffect(() => {
-    postFormStore.clearStates();
-  }, []);
-
-  const {
-    gameExercise,
-    gameStartTimeAmPm,
-    gameStartHour,
-    gameStartMinute,
-    gameEndTimeAmPm,
-    gameEndHour,
-    gameEndMinute,
-    gameDate,
-    placeName,
-    gameTargetMemberCount,
-    postDetail,
-    formErrors,
-    serverError,
-  } = postFormStore;
-
-  const data = {
-    gameExercise,
-    gameStartTimeAmPm,
-    gameStartHour,
-    gameStartMinute,
-    gameEndTimeAmPm,
-    gameEndHour,
-    gameEndMinute,
-    gameDate,
-    placeName,
-    gameTargetMemberCount,
-    postDetail,
-  };
-
-  const seeReconfirmModal = ({ targetAction, message }) => {
-    setAction(targetAction);
-    setActionMessage(message);
-    setReconfirmModalState(true);
-  };
-
-  const clearStates = () => {
-    postFormStore.clearStates();
-  };
-
   const navigateBackward = () => {
-    clearStates();
     navigate(previousPath || '/');
   };
 
-  const reconfirmNavigateBackward = () => {
-    seeReconfirmModal({
-      targetAction: () => navigateBackward,
-      message: '게시글 작성을 중단',
+  const navigatePostsAfterCreated = async () => {
+    navigate('/posts/list', {
+      state: {
+        postStatus: 'created',
+      },
     });
-  };
-
-  const changeGameExercise = (exercise) => {
-    postFormStore.changeGameExercise(exercise);
-  };
-
-  const changeGameDate = (date) => {
-    postFormStore.changeGameDate(date);
-  };
-
-  const changeGameStartTimeAmPm = (startTimeAmPm) => {
-    postFormStore.changeGameStartTimeAmPm(startTimeAmPm);
-  };
-
-  const changeGameStartHour = (startHour) => {
-    postFormStore.changeGameStartHour(startHour);
-  };
-
-  const changeGameStartMinute = (startMinute) => {
-    postFormStore.changeGameStartMinute(startMinute);
-  };
-
-  const changeGameEndTimeAmPm = (endTimeAmPm) => {
-    postFormStore.changeGameEndTimeAmPm(endTimeAmPm);
-  };
-
-  const changeGameEndHour = (endHour) => {
-    postFormStore.changeGameEndHour(endHour);
-  };
-
-  const changeGameEndMinute = (endMinute) => {
-    postFormStore.changeGameEndMinute(endMinute);
-  };
-
-  const changePlaceName = (place) => {
-    postFormStore.changePlaceName(place);
-  };
-
-  const changeGameTargetMemberCount = (targetMemberCount) => {
-    postFormStore.changeGameTargetMemberCount(targetMemberCount);
-  };
-
-  const changePostDetail = (detail) => {
-    postFormStore.changePostDetail(detail);
-  };
-
-  const reconfirmResetForm = () => {
-    seeReconfirmModal({
-      targetAction: () => clearStates,
-      message: '입력 내용을 초기화',
-    });
-  };
-
-  const createPost = async () => {
-    const postId = await postFormStore.createPost();
-    if (postId) {
-      clearStates();
-      navigate('/posts/list', {
-        state: {
-          postStatus: 'created',
-        },
-      });
-    }
   };
 
   return (
-    <>
-      <PostForm
-        data={data}
-        reconfirmNavigateBackward={reconfirmNavigateBackward}
-        changeGameExercise={changeGameExercise}
-        changeGameDate={changeGameDate}
-        changeGameStartTimeAmPm={changeGameStartTimeAmPm}
-        changeGameStartHour={changeGameStartHour}
-        changeGameStartMinute={changeGameStartMinute}
-        changeGameEndTimeAmPm={changeGameEndTimeAmPm}
-        changeGameEndHour={changeGameEndHour}
-        changeGameEndMinute={changeGameEndMinute}
-        changePlaceName={changePlaceName}
-        changeGameTargetMemberCount={changeGameTargetMemberCount}
-        changePostDetail={changePostDetail}
-        resetForm={reconfirmResetForm}
-        createPost={createPost}
-        formErrors={formErrors}
-        serverError={serverError}
-      />
-      {reconfirmModalState && (
-        <ModalReconfirm
-          action={action}
-          actionMessage={actionMessage}
-          reconfirmModalState={reconfirmModalState}
-          setReconfirmModalState={setReconfirmModalState}
-        />
-      )}
-    </>
+    <PostForm
+      navigateBackward={navigateBackward}
+      navigatePostsAfterCreated={navigatePostsAfterCreated}
+    />
   );
 }

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,27 +1,11 @@
-/* eslint-disable no-nested-ternary */
-
-import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useLocalStorage } from 'usehooks-ts';
-import Post from '../components/Post';
-import usePostStore from '../hooks/usePostStore';
-import useGameStore from '../hooks/useGameStore';
-import usePlaceStore from '../hooks/usePlaceStore';
-import useRegisterStore from '../hooks/useRegisterStore';
 
-import ModalConfirm from '../components/ModalConfirm';
-import ModalReconfirm from '../components/ModalReconfirm';
+import Post from '../components/Post';
 
 export default function PostPage() {
   const [accessToken] = useLocalStorage('accessToken', '');
   const loggedIn = accessToken !== '';
-
-  const [registerId, setRegisterId] = useState(0);
-  const [postIdToBeDeleted, setPostIdToBeDeleted] = useState(0);
-  const [actionName, setActionName] = useState('');
-  const [actionMessage, setActionMessage] = useState('');
-  const [confirmModalState, setConfirmModalState] = useState(false);
-  const [reconfirmModalState, setReconfirmModalState] = useState(false);
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -29,36 +13,6 @@ export default function PostPage() {
   const postId = location.state !== null
     ? location.state.postId
     : Number(location.pathname.split('/')[2]);
-
-  const postStore = usePostStore();
-  const gameStore = useGameStore();
-  const placeStore = usePlaceStore();
-  const registerStore = useRegisterStore();
-
-  const fetchData = async () => {
-    await postStore.fetchPost(postId);
-    const gameId = await gameStore.fetchGame(postId);
-    const { isAuthor } = postStore.post;
-    const { placeId } = gameStore.game;
-    await placeStore.fetchPlace(placeId);
-    await registerStore.fetchMembers(gameId);
-    if (isAuthor) {
-      await registerStore.fetchApplicants(gameId);
-    }
-  };
-
-  useEffect(() => {
-    fetchData(postId);
-  }, [accessToken]);
-
-  const { post } = postStore;
-  const { game } = gameStore;
-  const { place } = placeStore;
-  const {
-    members,
-    applicants,
-    registerServerError,
-  } = registerStore;
 
   const navigateBackward = () => {
     navigate('/posts/list');
@@ -82,29 +36,7 @@ export default function PostPage() {
     });
   };
 
-  const seeConfirmModal = ({ message }) => {
-    setActionMessage(message);
-    setConfirmModalState(true);
-  };
-
-  const seeReconfirmModal = ({ action, message }) => {
-    setActionName(action);
-    setActionMessage(message);
-    setReconfirmModalState(true);
-  };
-
-  const hideReconfirmModal = () => {
-    setActionName('');
-    setReconfirmModalState(false);
-  };
-
-  const reconfirmDeletePost = (targetPostId) => {
-    setPostIdToBeDeleted(targetPostId);
-    seeReconfirmModal({ action: 'deletePost', message: '게시글을 삭제' });
-  };
-
-  const deletePost = async () => {
-    await postStore.deletePost(postIdToBeDeleted);
+  const navigatePostsAfterDeleted = () => {
     navigate('/posts/list', {
       state: {
         postStatus: 'deleted',
@@ -112,100 +44,14 @@ export default function PostPage() {
     });
   };
 
-  const handleClickRegister = async (gameId) => {
-    const applicationId = await registerStore.registerToGame(gameId);
-    if (applicationId) {
-      await fetchData(postId);
-      seeConfirmModal({ message: '참가 신청이' });
-    }
-  };
-
-  const reconfirmRegisterCancel = (targetRegisterId) => {
-    setRegisterId(targetRegisterId);
-    seeReconfirmModal({ action: 'registerCancel', message: '참가 신청을 취소' });
-  };
-
-  const reconfirmParticipateCancel = (targetRegisterId) => {
-    setRegisterId(targetRegisterId);
-    seeReconfirmModal({ action: 'participateCancel', message: '참가를 취소' });
-  };
-
-  const reconfirmRegisterReject = (targetRegisterId) => {
-    setRegisterId(targetRegisterId);
-    seeReconfirmModal({ action: 'registerReject', message: '참가 신청을 거절' });
-  };
-
-  const cancelRegister = async () => {
-    await registerStore.cancelRegisterToGame(registerId);
-    await fetchData(postId);
-    hideReconfirmModal();
-    seeConfirmModal({ message: '참가 신청 취소가' });
-  };
-
-  const cancelParticipate = async () => {
-    await registerStore.cancelParticipateToGame(registerId);
-    await fetchData(postId);
-    hideReconfirmModal();
-    seeConfirmModal({ message: '참가 취소가' });
-  };
-
-  const handleClickAcceptRegister = async (targetRegisterId) => {
-    await registerStore.acceptRegister(targetRegisterId);
-    await fetchData(postId);
-    seeConfirmModal({ message: '참가 신청 수락이' });
-  };
-
-  const rejectRegister = async () => {
-    await registerStore.rejectRegister(registerId);
-    await fetchData(postId);
-    hideReconfirmModal();
-    seeConfirmModal({ message: '참가 신청 거절이' });
-  };
-
   return (
-    <>
-      <Post
-        loggedIn={loggedIn}
-        navigateBackward={navigateBackward}
-        navigateLogin={navigateLogin}
-        navigateSelectTrialAccount={navigateSelectTrialAccount}
-        post={post}
-        game={game}
-        place={place}
-        members={members}
-        applicants={applicants}
-        reconfirmDeletePost={reconfirmDeletePost}
-        handleClickRegister={handleClickRegister}
-        reconfirmRegisterCancel={reconfirmRegisterCancel}
-        reconfirmParticipateCancel={reconfirmParticipateCancel}
-        handleClickAcceptRegister={handleClickAcceptRegister}
-        reconfirmRegisterReject={reconfirmRegisterReject}
-        registerError={registerServerError}
-      />
-      {confirmModalState && (
-        <ModalConfirm
-          actionMessage={actionMessage}
-          confirmModalState={confirmModalState}
-          setConfirmModalState={setConfirmModalState}
-        />
-      )}
-      {/* TODO: Modal에 함수를 전달할 수 있음, 이렇게 지저분하게 전달하지 않아도 되므로
-            Github Project에 남긴 Modal 추가 Task를 보고 수정할 것 */}
-      {reconfirmModalState && (
-        <ModalReconfirm
-          action={(
-            actionName === 'registerCancel' ? cancelRegister
-              : actionName === 'participateCancel' ? cancelParticipate
-                : actionName === 'registerReject' ? rejectRegister
-                  : actionName === 'deletePost' ? deletePost
-                    : null
-          )}
-          actionMessage={actionMessage}
-          reconfirmModalState={reconfirmModalState}
-          setReconfirmModalState={setReconfirmModalState}
-        />
-      )}
-    </>
-
+    <Post
+      loggedIn={loggedIn}
+      postId={postId}
+      navigateBackward={navigateBackward}
+      navigateLogin={navigateLogin}
+      navigateSelectTrialAccount={navigateSelectTrialAccount}
+      navigatePostsAfterDeleted={navigatePostsAfterDeleted}
+    />
   );
 }

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -1,13 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { useLocalStorage } from 'usehooks-ts';
-
-import usePostStore from '../hooks/usePostStore';
-
+import ComponentScreenContainer from '../components/ui/ComponentScreenContainer';
 import Posts from '../components/Posts';
-import { postApiService } from '../services/PostApiService';
 import ModalConfirm from '../components/ModalConfirm';
+import PostsSearchAndSettings from '../components/PostsSearchAndSettings';
 
 export default function PostsPage() {
   const [actionMessage, setActionMessage] = useState('');
@@ -19,14 +16,6 @@ export default function PostsPage() {
   const postStatus = !location.state
     ? null
     : location.state.postStatus;
-
-  const [accessToken] = useLocalStorage('accessToken', '');
-  const loggedIn = accessToken !== '';
-
-  const [searchSetting, toggleSearchSetting] = useState(false);
-  const [filterSetting, toggleFilterSetting] = useState(false);
-
-  const postStore = usePostStore();
 
   const seeConfirmModal = ({ message }) => {
     setActionMessage(message);
@@ -41,24 +30,7 @@ export default function PostsPage() {
           : '게시글 삭제가',
       });
     }
-    postApiService.setAccessToken(accessToken);
-    postStore.fetchPosts();
-  }, [accessToken]);
-
-  const {
-    posts,
-    postsServerError,
-  } = postStore;
-
-  const handleClickToggleSearchSetting = () => {
-    toggleSearchSetting(!searchSetting);
-    toggleFilterSetting(false);
-  };
-
-  const handleClickToggleFilterSetting = () => {
-    toggleSearchSetting(false);
-    toggleFilterSetting(!filterSetting);
-  };
+  }, []);
 
   const navigatePost = (postId) => {
     navigate(`/posts/${postId}`, {
@@ -69,16 +41,10 @@ export default function PostsPage() {
   };
 
   return (
-    <>
+    <ComponentScreenContainer>
+      <PostsSearchAndSettings />
       <Posts
-        loggedIn={loggedIn}
-        searchSetting={searchSetting}
-        filterSetting={filterSetting}
-        toggleSearchSetting={handleClickToggleSearchSetting}
-        toggleFilterSetting={handleClickToggleFilterSetting}
-        posts={posts}
         navigatePost={navigatePost}
-        postsServerError={postsServerError}
       />
       {confirmModalState && (
         <ModalConfirm
@@ -87,6 +53,6 @@ export default function PostsPage() {
           setConfirmModalState={setConfirmModalState}
         />
       )}
-    </>
+    </ComponentScreenContainer>
   );
 }

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -36,31 +36,17 @@ export default class PostApiService {
   }
 
   async createPost({
-    gameExercise,
-    gameDate,
-    gameStartTimeAmPm,
-    gameStartHour,
-    gameStartMinute,
-    gameEndTimeAmPm,
-    gameEndHour,
-    gameEndMinute,
-    placeName,
-    gameTargetMemberCount,
-    postDetail,
+    post,
+    game,
+    exercise,
+    place,
   }) {
     const url = `${apiBaseUrl}/posts`;
     const { data } = await axios.post(url, {
-      gameExercise,
-      gameDate,
-      gameStartTimeAmPm,
-      gameStartHour,
-      gameStartMinute,
-      gameEndTimeAmPm,
-      gameEndHour,
-      gameEndMinute,
-      placeName,
-      gameTargetMemberCount,
-      postDetail,
+      post,
+      game,
+      exercise,
+      place,
     }, {
       headers: {
         Authorization: `Bearer ${this.accessToken}`,

--- a/src/services/RegisterApiService.js
+++ b/src/services/RegisterApiService.js
@@ -37,7 +37,7 @@ export default class RegisterApiService {
     return data.gameId;
   }
 
-  async cancelRegisterToGame(registerId) {
+  async cancelRegisterGame(registerId) {
     const url = `${apiBaseUrl}/registers/${registerId}`;
     await axios.patch(url, { }, {
       params: { status: 'canceled' },
@@ -47,7 +47,7 @@ export default class RegisterApiService {
     });
   }
 
-  async cancelParticipateToGame(registerId) {
+  async cancelParticipateGame(registerId) {
     const url = `${apiBaseUrl}/registers/${registerId}`;
     await axios.patch(url, { }, {
       params: { status: 'canceled' },

--- a/src/stores/PostFormStore.js
+++ b/src/stores/PostFormStore.js
@@ -237,18 +237,31 @@ export default class PostFormStore extends Store {
         return '';
       }
 
+      const post = {
+        detail: this.postDetail,
+      };
+      const game = {
+        date: this.gameDate.toISOString(),
+        startTimeAmPm: this.gameStartTimeAmPm,
+        startHour: this.gameStartHour,
+        startMinute: this.gameStartMinute,
+        endTimeAmPm: this.gameEndTimeAmPm,
+        endHour: this.gameEndHour,
+        endMinute: this.gameEndMinute,
+        targetMemberCount: this.gameTargetMemberCount,
+      };
+      const exercise = {
+        name: this.gameExercise,
+      };
+      const place = {
+        name: this.placeName,
+      };
+
       const data = await postApiService.createPost({
-        gameExercise: this.gameExercise,
-        gameDate: this.gameDate.toISOString(),
-        gameStartTimeAmPm: this.gameStartTimeAmPm,
-        gameStartHour: this.gameStartHour,
-        gameStartMinute: this.gameStartMinute,
-        gameEndTimeAmPm: this.gameEndTimeAmPm,
-        gameEndHour: this.gameEndHour,
-        gameEndMinute: this.gameEndMinute,
-        placeName: this.placeName,
-        gameTargetMemberCount: this.gameTargetMemberCount,
-        postDetail: this.postDetail,
+        post,
+        game,
+        exercise,
+        place,
       });
       return data.postId;
     } catch (error) {

--- a/src/stores/PostStore.js
+++ b/src/stores/PostStore.js
@@ -8,11 +8,82 @@ export default class PostStore extends Store {
   constructor() {
     super();
 
+    this.searchKeyword = '';
+
+    this.exerciseSelection = false;
+    this.placeSelection = false;
+    this.authorSelection = false;
+    this.memberSelection = false;
+    this.applicantSelection = false;
+
+    this.registeredSelection = false;
+    this.writtenSelection = false;
+
     this.posts = [];
     this.postsServerError = '';
 
     this.post = {};
     this.postServerError = '';
+  }
+
+  resetSearchConditionState() {
+    this.exerciseSelection = false;
+    this.placeSelection = false;
+    this.authorSelection = false;
+    this.memberSelection = false;
+    this.applicantSelection = false;
+  }
+
+  // TODO: 내가 참가하는 운동, 내가 작성한 운동 조회는
+  //   선택 시 바로 filtering에 들어갈 수 있을 것 같음
+
+  resetLookUpConditionState() {
+    this.registeredSelection = false;
+    this.writtenSelection = false;
+  }
+
+  changeExerciseSelection() {
+    this.resetLookUpConditionState();
+    this.exerciseSelection = !this.exerciseSelection;
+    this.publish();
+  }
+
+  changePlaceSelection() {
+    this.resetLookUpConditionState();
+    this.placeSelection = !this.placeSelection;
+    this.publish();
+  }
+
+  changeAuthorSelection() {
+    this.resetLookUpConditionState();
+    this.authorSelection = !this.authorSelection;
+    this.publish();
+  }
+
+  changeMemberSelection() {
+    this.resetLookUpConditionState();
+    this.memberSelection = !this.memberSelection;
+    this.publish();
+  }
+
+  changeApplicantSelection() {
+    this.resetLookUpConditionState();
+    this.applicantSelection = !this.applicantSelection;
+    this.publish();
+  }
+
+  setRegisteredSelection() {
+    this.resetSearchConditionState();
+    this.registeredSelection = true;
+    this.writtenSelection = false;
+    this.publish();
+  }
+
+  setWrittenSelection() {
+    this.resetSearchConditionState();
+    this.registeredSelection = false;
+    this.writtenSelection = true;
+    this.publish();
   }
 
   async fetchPosts() {

--- a/src/stores/RegisterStore.js
+++ b/src/stores/RegisterStore.js
@@ -52,12 +52,12 @@ export default class RegisterStore extends Store {
     }
   }
 
-  async cancelRegisterToGame(registerId) {
-    await registerApiService.cancelRegisterToGame(registerId);
+  async cancelRegisterGame(registerId) {
+    await registerApiService.cancelRegisterGame(registerId);
   }
 
-  async cancelParticipateToGame(registerId) {
-    await registerApiService.cancelParticipateToGame(registerId);
+  async cancelParticipateGame(registerId) {
+    await registerApiService.cancelParticipateGame(registerId);
   }
 
   async acceptRegister(registerId) {


### PR DESCRIPTION
지금까지의 문제점
- 모든 기능들이 페이지 컴포넌트에서 Store를 참조해서 데이터를 꺼내고 -> 하위 컴포넌트들에 prop들로 한번에 내려주고 있음
- 규모가 커질수록 내려줘야 하는 데이터와 핸들러 함수들이 많아짐에 따라 prop들이 많아지면서 기능 추가 및 수정 시 소스코드 이해에 인지자원이 크게 소모됨

계획
- Page에서 내려주고 있는 prop들을 각 컴포넌트에서 Store를 직접 참조하도록 변경
  - 핸들러 함수 실행 역시 페이지 이동 관련 핸들러 함수를 제외하고 모두 개별 컴포넌트에서 Store의 메서드에 직접 접근
- 특정 컴포넌트의 상태 변경이 다른 컴포넌트의 변경을 유도해야 하는 경우 변경되어야 하는 컴포넌트에서 특정 컴포넌트의 상태를 참조 (useEffect 안에서)
- Page 컴포넌트는 네비게이션과 같은 화면 이동과 관련된 작업만 수행

목표
- 리팩터링을 하고 난 뒤에도 페이지 동작을 리팩터링 이전과 같이 수행

리팩터링한 페이지 목록
- PostsPage
- PostPage
- PostFormPage
- NoticesPage

추가 진행 필요 작업
- 단위 테스트는 수정하지 않음, 전체적으로 다시 작성되어야 함

회고
- 하나의 페이지 컴포넌트에 연결된 컴포넌트들을 수정을 마칠 때마다 Commit을 올리는 것도 괜찮았을 것 같음
  - 다른 컴포넌트를 수정하다가 돌이키기 어려운 오류를 발생시켰을 경우에는 뒤로 돌려야 할 경우가 있을 수 있을 것 같음

15.5뽀모 사용