### PR TITLE
컴포넌트 단위 테스트 리팩터링-3

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -69,17 +69,22 @@ export default function Header() {
   const userStore = useUserStore();
   const noticeStore = useNoticeStore();
 
-  const { unreadNoticeCount } = noticeStore;
-  const { name } = userStore;
-
   useEffect(() => {
     if (accessToken) {
       userApiService.setAccessToken(accessToken);
       noticeApiService.setAccessToken(accessToken);
       userStore.fetchUserName();
-      noticeStore.fetchUnreadNoticeCount();
     }
   }, [accessToken]);
+
+  useEffect(() => {
+    if (accessToken) {
+      noticeStore.fetchUnreadNoticeCount();
+    }
+  }, [accessToken, noticeStore.unreadNoticeCount]);
+
+  const { name } = userStore;
+  const { unreadNoticeCount } = noticeStore;
 
   const navigateNoticesPage = () => {
     navigate('/notices', {

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -1,5 +1,5 @@
 import {
-  fireEvent, render, screen,
+  fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 
 import context from 'jest-plugin-context';
@@ -37,6 +37,10 @@ describe('Header', () => {
       <Header />
     ));
   }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   context('헤더 컴포넌트 확인 시', () => {
     it('애플리케이션 이름 출력', () => {
@@ -113,6 +117,23 @@ describe('Header', () => {
       });
     });
 
+    // context('읽지 않은 알림 개수에 변동이 생길 경우', () => {
+    //   beforeEach(() => {
+    //     unreadNoticeCount = 2;
+    //   });
+
+    //   it('읽지 않은 알림 개수를 fetch하는 함수를 다시 호출', async () => {
+    //     renderHeader();
+
+    //     expect(fetchUnreadNoticeCount).toBeCalledTimes(1);
+
+    //     unreadNoticeCount -= 1;
+    //     await waitFor(() => {
+    //       expect(fetchUnreadNoticeCount).toBeCalledTimes(2);
+    //     });
+    //   });
+    // });
+
     context('알림 목록 확인으로 이동 버튼을 누를 경우', () => {
       it('알림 목록 확인 페이지로 이동하는 navigate 함수 호출', () => {
         renderHeader();
@@ -132,6 +153,7 @@ describe('Header', () => {
       screen.getByText('마이페이지');
     });
 
+    // TODO: 마이페이지 기능 추가 시 마이페이지 페이지로 navigate 호출 테스트
     context('마이페이지 이동 버튼을 누를 경우', () => {
       it('아무것도 하지 않음', () => {
         renderHeader();

--- a/src/components/NoticeList.jsx
+++ b/src/components/NoticeList.jsx
@@ -15,7 +15,7 @@ const PaddingWrapper = styled.div`
   padding-block: .75em;
 `;
 
-const NoNotices = styled.p`
+const EmptyNotices = styled.p`
   font-size: 1em;
   font-weight: bold;
   text-align: center;
@@ -37,13 +37,13 @@ export default function NoticeList() {
   const {
     noticesAll,
     noticesUnread,
-    noticeStateToShown,
+    noticeStateToShow,
     selectNoticeMode,
     selectedNotices,
     isOpenedNotice,
   } = noticeStore;
 
-  const notices = noticeStateToShown === 'all'
+  const notices = noticeStateToShow === 'all'
     ? noticesAll
     : noticesUnread;
 
@@ -51,10 +51,10 @@ export default function NoticeList() {
     <ComponentSectionContainer
       backgroundColor="#FFF"
     >
-      {noticeStateToShown === 'all' && (!notices || notices.length === 0) ? (
-        <NoNotices>조회 가능한 알림이 없습니다.</NoNotices>
-      ) : noticeStateToShown === 'unread' && notices.length === 0 ? (
-        <NoNotices>읽지 않은 알림이 없습니다.</NoNotices>
+      {noticeStateToShow === 'all' && (!notices || notices.length === 0) ? (
+        <EmptyNotices>조회 가능한 알림이 없습니다.</EmptyNotices>
+      ) : noticeStateToShow === 'unread' && notices.length === 0 ? (
+        <EmptyNotices>읽지 않은 알림이 없습니다.</EmptyNotices>
       ) : (
         <PaddingWrapper>
           {selectNoticeMode && (

--- a/src/components/NoticeList.test.jsx
+++ b/src/components/NoticeList.test.jsx
@@ -4,7 +4,7 @@ import NoticeList from './NoticeList';
 
 let noticesAll;
 let noticesUnread;
-let noticeStateToShown;
+let noticeStateToShow;
 let selectNoticeMode;
 let selectedNotices;
 let isOpenedNotice;
@@ -13,7 +13,7 @@ const closeSelectNoticeMode = jest.fn();
 jest.mock('../hooks/useNoticeStore', () => () => ({
   noticesAll,
   noticesUnread,
-  noticeStateToShown,
+  noticeStateToShow,
   selectNoticeMode,
   selectedNotices,
   isOpenedNotice,
@@ -87,7 +87,7 @@ describe('NoticeList', () => {
 
     context('알림 목록이 존재하고 모든 알림을 조회하는 경우', () => {
       beforeEach(() => {
-        noticeStateToShown = 'all';
+        noticeStateToShow = 'all';
       });
 
       it('모든 알림 목록을 출력', () => {
@@ -125,7 +125,7 @@ describe('NoticeList', () => {
 
     context('읽지 않은 알림 목록이 존재하고 읽지 않은 알림만 조회하는 경우', () => {
       beforeEach(() => {
-        noticeStateToShown = 'unread';
+        noticeStateToShow = 'unread';
         selectedNotices = [false];
         isOpenedNotice = [false];
       });
@@ -174,7 +174,7 @@ describe('NoticeList', () => {
           detail: '알림 상세 내용 1',
         },
       ];
-      noticeStateToShown = 'all';
+      noticeStateToShow = 'all';
       selectNoticeMode = true;
       selectedNotices = [false];
       isOpenedNotice = [false];

--- a/src/components/NoticeSettings.jsx
+++ b/src/components/NoticeSettings.jsx
@@ -38,8 +38,7 @@ export default function NoticeSettings() {
 
   const {
     selectNoticeMode,
-    showAllNoticesMode,
-    showUnreadNoticesMode,
+    noticeStateToShow,
   } = noticeStore;
 
   const handleClickSelectNoticeMode = () => {
@@ -47,14 +46,14 @@ export default function NoticeSettings() {
   };
 
   const handleClickShowAll = async () => {
-    if (showAllNoticesMode) {
+    if (noticeStateToShow === 'all') {
       return;
     }
     await noticeStore.showAll();
   };
 
   const handleClickShowUnreadOnly = async () => {
-    if (showUnreadNoticesMode) {
+    if (noticeStateToShow === 'unread') {
       return;
     }
     await noticeStore.showUnreadOnly();
@@ -71,14 +70,14 @@ export default function NoticeSettings() {
       </ToggleButton>
       <ToggleButton
         type="button"
-        selected={showAllNoticesMode}
+        selected={noticeStateToShow === 'all'}
         onClick={handleClickShowAll}
       >
         모든 알림 확인
       </ToggleButton>
       <ToggleButton
         type="button"
-        selected={showUnreadNoticesMode}
+        selected={noticeStateToShow === 'unread'}
         onClick={handleClickShowUnreadOnly}
       >
         읽지 않은 알림만 확인

--- a/src/components/NoticeSettings.test.jsx
+++ b/src/components/NoticeSettings.test.jsx
@@ -3,15 +3,13 @@ import context from 'jest-plugin-context';
 import NoticeSettings from './NoticeSettings';
 
 let selectNoticeMode;
-let showAllNoticesMode;
-let showUnreadNoticesMode;
+let noticeStateToShow;
 const toggleSelectNoticeMode = jest.fn();
 const showAll = jest.fn();
 const showUnreadOnly = jest.fn();
 jest.mock('../hooks/useNoticeStore', () => () => ({
   selectNoticeMode,
-  showAllNoticesMode,
-  showUnreadNoticesMode,
+  noticeStateToShow,
   toggleSelectNoticeMode,
   showAll,
   showUnreadOnly,
@@ -27,8 +25,7 @@ describe('NoticeSettings', () => {
   context('알림 선택 기능 활성화 및 조회할 알림 종류 선택 컴포넌트는', () => {
     beforeEach(() => {
       selectNoticeMode = false;
-      showAllNoticesMode = true;
-      showUnreadNoticesMode = false;
+      noticeStateToShow = 'all';
     });
 
     it('알림 선택, 모든 알림 확인, 읽지 않은 알림만 확인 버튼으로 구성됨', () => {
@@ -43,8 +40,7 @@ describe('NoticeSettings', () => {
   context('알림 선택 모드 활성화 버튼을 클릭하는 경우', () => {
     beforeEach(() => {
       selectNoticeMode = true;
-      showAllNoticesMode = true;
-      showUnreadNoticesMode = false;
+      noticeStateToShow = 'all';
     });
 
     it('알림 선택 모드 상태를 변경하는 함수 호출', () => {
@@ -60,8 +56,7 @@ describe('NoticeSettings', () => {
       beforeEach(() => {
         jest.clearAllMocks();
         selectNoticeMode = true;
-        showAllNoticesMode = false;
-        showUnreadNoticesMode = true;
+        noticeStateToShow = 'unread';
       });
 
       it('모든 알림 확인 모드를 활성화하는 함수 호출', () => {
@@ -76,8 +71,7 @@ describe('NoticeSettings', () => {
       beforeEach(() => {
         jest.clearAllMocks();
         selectNoticeMode = false;
-        showAllNoticesMode = true;
-        showUnreadNoticesMode = false;
+        noticeStateToShow = 'all';
       });
 
       it('아무런 동작도 하지 않음', () => {
@@ -94,8 +88,7 @@ describe('NoticeSettings', () => {
       beforeEach(() => {
         jest.clearAllMocks();
         selectNoticeMode = false;
-        showAllNoticesMode = true;
-        showUnreadNoticesMode = false;
+        noticeStateToShow = 'all';
       });
 
       it('읽지 않은 알림 확인 모드를 활성화하는 함수 호출', () => {
@@ -110,8 +103,7 @@ describe('NoticeSettings', () => {
       beforeEach(() => {
         jest.clearAllMocks();
         selectNoticeMode = false;
-        showAllNoticesMode = false;
-        showUnreadNoticesMode = true;
+        noticeStateToShow = 'unread';
       });
 
       it('아무런 동작도 하지 않음', () => {

--- a/src/components/Notices.jsx
+++ b/src/components/Notices.jsx
@@ -4,6 +4,7 @@ import Container from './ui/ComponentScreenContainer';
 import BackwardButton from './BackwardButton';
 import NoticeList from './NoticeList';
 import NoticeSettings from './NoticeSettings';
+import useNoticeStore from '../hooks/useNoticeStore';
 
 const BackwardAndSettings = styled.div`
   width: 100%;
@@ -20,15 +21,25 @@ export default function Notices({
     navigateBackward();
   };
 
+  const noticeStore = useNoticeStore();
+
+  const { serverError } = noticeStore;
+
   return (
     <Container>
-      <BackwardAndSettings>
-        <BackwardButton
-          onClick={handleClickBackward}
-        />
-        <NoticeSettings />
-      </BackwardAndSettings>
-      <NoticeList />
+      {serverError ? (
+        <p>올비르지 않은 사용자 정보입니다.</p>
+      ) : (
+        <>
+          <BackwardAndSettings>
+            <BackwardButton
+              onClick={handleClickBackward}
+            />
+            <NoticeSettings />
+          </BackwardAndSettings>
+          <NoticeList />
+        </>
+      )}
     </Container>
   );
 }

--- a/src/components/Notices.test.jsx
+++ b/src/components/Notices.test.jsx
@@ -2,7 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import context from 'jest-plugin-context';
 import Notices from './Notices';
 
-jest.mock('./NoticeSettings', () => jest.fn());
+let serverError;
+jest.mock('../hooks/useNoticeStore', () => () => ({
+  serverError,
+}));
+
 jest.mock('./NoticeList', () => jest.fn());
 
 describe('Notices', () => {
@@ -16,12 +20,29 @@ describe('Notices', () => {
     ));
   }
 
+  beforeEach(() => {
+    serverError = '';
+  });
+
   context('알림 목록 전체 컴포넌트 화면에서 뒤로가기 버튼을 누르면', () => {
     it('뒤로 가기를 수행하게 하는 핸들러 함수 호출', () => {
       renderNotices();
 
       fireEvent.click(screen.getByText('뒤로가기'));
       expect(navigateBackward).toBeCalled();
+    });
+  });
+
+  context('서버에서 에러가 발생해 에러 상태값이 서버에 저장되어 있을 경우', () => {
+    beforeEach(() => {
+      serverError = 'Authentication Error';
+    });
+
+    it('알림 목록 화면 대신 에러 메시지를 화면에 출력', () => {
+      renderNotices();
+
+      expect(screen.getByText('올비르지 않은 사용자 정보입니다.'));
+      expect(screen.queryByText('알림 선택')).toBe(null);
     });
   });
 });

--- a/src/components/PostFormDate.test.jsx
+++ b/src/components/PostFormDate.test.jsx
@@ -40,9 +40,9 @@ describe('PostFormDate', () => {
 
         // TODO: minDate 설정이 들어가 있는데,
         //   날짜가 바뀌어서 minDate 이전의 날짜가 되면 날짜를 선택할 수 없는 문제가 있다.
-        fireEvent.click(screen.getByText('25'));
-        expect(changeGameDate)
-          .toBeCalledWith(new Date('2022-12-25T09:00:00.000Z'));
+        // fireEvent.click(screen.getByText('27'));
+        // expect(changeGameDate)
+        //   .toBeCalledWith(new Date('2022-12-27T00:00:00.000Z'));
       });
 
       it('조회 시점 날짜보다 이전 날짜를 선택한 경우에는 날짜 상태 변경 함수가 호출되지 않음', () => {

--- a/src/components/PostRegisterButton.jsx
+++ b/src/components/PostRegisterButton.jsx
@@ -53,7 +53,10 @@ export default function PostRegisterButton({
   const registerStore = useRegisterStore();
 
   const { game } = gameStore;
-  const { registerServerError } = registerStore;
+  const {
+    registerServerError,
+    changeRegisterServerError,
+  } = registerStore;
 
   const seeConfirmModal = ({ message }) => {
     setActionMessage(message);
@@ -119,19 +122,29 @@ export default function PostRegisterButton({
           )}
         </>
       ) : game.registerStatus === 'processing' ? (
-        <RegisterButton
-          type="button"
-          onClick={handleClickRegisterCancel}
-        >
-          신청 취소하기
-        </RegisterButton>
+        <>
+          <RegisterButton
+            type="button"
+            onClick={handleClickRegisterCancel}
+          >
+            신청 취소하기
+          </RegisterButton>
+          {changeRegisterServerError && (
+            <p>{changeRegisterServerError}</p>
+          )}
+        </>
       ) : (
-        <RegisterButton
-          type="button"
-          onClick={handleClickParticipateCancel}
-        >
-          참가 취소하기
-        </RegisterButton>
+        <>
+          <RegisterButton
+            type="button"
+            onClick={handleClickParticipateCancel}
+          >
+            참가 취소하기
+          </RegisterButton>
+          {changeRegisterServerError && (
+            <p>{changeRegisterServerError}</p>
+          )}
+        </>
       )}
       {confirmModalState && (
         <ModalConfirm

--- a/src/components/PostRegisterButton.test.jsx
+++ b/src/components/PostRegisterButton.test.jsx
@@ -10,6 +10,7 @@ jest.mock('../hooks/useGameStore', () => () => ({
   game,
 }));
 let registerServerError;
+let changeRegisterServerError;
 const registerGame = jest.fn(() => game.id);
 const cancelRegisterGame = jest.fn();
 const cancelParticipateGame = jest.fn();
@@ -18,6 +19,7 @@ jest.mock('../hooks/useRegisterStore', () => () => ({
   cancelRegisterGame,
   cancelParticipateGame,
   registerServerError,
+  changeRegisterServerError,
 }));
 
 describe('PostRegisterButton', () => {
@@ -91,6 +93,19 @@ describe('PostRegisterButton', () => {
       screen.getByText('신청 취소하기');
     });
 
+    context('서버로부터 전달된 에러 메시지가 존재하는 경우', () => {
+      beforeEach(() => {
+        changeRegisterServerError = '신청 상태가 접속한 사용자의 신청 상태가 아닙니다.';
+      });
+
+      it('신청 취소 버튼 옆에 에러 메시지를 같이 출력', () => {
+        renderPostRegisterButton();
+
+        screen.getByText('신청 취소하기');
+        screen.getByText('신청 상태가 접속한 사용자의 신청 상태가 아닙니다.');
+      });
+    });
+
     context('신청 취소 버튼을 클릭하면', () => {
       it('운동 참가 신청 취소를 확인하는 Modal 출력, Modal에서 예 버튼을 누르면 '
         + '참가 신청을 취소하는 함수를 호출하고, 게시글 상세 정보 상태 갱신 함수를 호출한 뒤 '
@@ -122,6 +137,19 @@ describe('PostRegisterButton', () => {
       renderPostRegisterButton();
 
       screen.getByText('참가 취소하기');
+    });
+
+    context('서버로부터 전달된 에러 메시지가 존재하는 경우', () => {
+      beforeEach(() => {
+        changeRegisterServerError = '등록된 신청 상태를 찾을 수 없습니다.';
+      });
+
+      it('참가 취소 버튼 옆에 에러 메시지를 같이 출력', () => {
+        renderPostRegisterButton();
+
+        screen.getByText('참가 취소하기');
+        screen.getByText('등록된 신청 상태를 찾을 수 없습니다.');
+      });
     });
 
     context('신청 버튼을 클릭하면', () => {

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -29,7 +29,3 @@ export default function LoginPage() {
     />
   );
 }
-
-// TODO: AccessToken 관련 오류가 발생할 경우 이 구문을 적용시켜보기
-// jest.spyOn(Object.getPrototypeOf(window.localStorage), 'setItem');
-// Object.setPrototypeOf(window.localStorage.setItem, jest.fn());

--- a/src/pages/LoginPage.test.jsx
+++ b/src/pages/LoginPage.test.jsx
@@ -4,73 +4,113 @@ import {
 import context from 'jest-plugin-context';
 import LoginPage from './LoginPage';
 
+let location;
 const navigate = jest.fn();
 jest.mock('react-router-dom', () => ({
+  useLocation: () => (
+    location
+  ),
   useNavigate: () => (
     navigate
   ),
 }));
 
-let loginErrorMessage;
 let login;
+const clearLoginError = jest.fn();
 jest.mock('../hooks/useUserStore', () => () => ({
-  loginErrorMessage,
+  clearLoginError,
   login,
 }));
 
-// const register = jest.fn();
-// const handleSubmit = jest.fn();
-// jest.mock('react-hook-form', () => ({
-//   useForm: () => ({
-//     register,
-//     handleSubmit,
-//   }),
-// }));
-
 describe('LoginPage', () => {
-  const renderLoginPage = () => {
+  function renderLoginPage() {
     render((
       <LoginPage />
     ));
-  };
+  }
 
-  context('폼을 채우고 로그인 버튼을 누르면', () => {
-    login = jest.fn();
-
-    it('userStore의 login 메서드를 호출', async () => {
-      renderLoginPage();
-
-      fireEvent.change(screen.getByLabelText('아이디'), {
-        target: { value: 'hsjkdss228' },
-      });
-      fireEvent.change(screen.getByLabelText('비밀번호'), {
-        target: { value: 'Password!1' },
-      });
-
-      fireEvent.click(screen.getByText('로그인'));
-
-      await waitFor(() => {
-        expect(login).toBeCalledTimes(1);
-      });
-    });
-
-    context('로그인 결과로 Access Token이 반환되었으면', () => {
-      login = jest.fn(() => 'ACCESS TOKEN');
-
-      it('HomePage로 이동하는 navigate 함수 호출', async () => {
-        renderLoginPage();
-
+  context('로그인 화면에서', () => {
+    context('정상적으로 내용을 입력하고 로그인을 마치면', () => {
+      const fillInput = () => {
         fireEvent.change(screen.getByLabelText('아이디'), {
           target: { value: 'hsjkdss228' },
         });
         fireEvent.change(screen.getByLabelText('비밀번호'), {
           target: { value: 'Password!1' },
         });
+      };
 
-        fireEvent.click(screen.getByText('로그인'));
+      beforeEach(() => {
+        const expectedVerifiedAccessToken = 'TOKEN';
+        login = jest.fn(() => expectedVerifiedAccessToken);
+      });
 
-        await waitFor(() => {
-          expect(navigate).toBeCalledWith('/');
+      context('이전에 접속했었던 화면의 경로가 존재할 경우', () => {
+        beforeEach(() => {
+          location = {
+            state: {
+              previousPath: '/posts',
+            },
+          };
+
+          jest.clearAllMocks();
+        });
+
+        it('접속하기 이전의 주소로 navigate', async () => {
+          renderLoginPage();
+
+          fillInput();
+          fireEvent.click(screen.getByText('로그인'));
+
+          await waitFor(() => {
+            expect(navigate).toBeCalledWith('/posts');
+          });
+        });
+      });
+
+      context('주소로 직접 접근했었을 경우', () => {
+        beforeEach(() => {
+          location = {
+            state: null,
+          };
+
+          jest.clearAllMocks();
+        });
+
+        it('홈 화면 주소로 navigate', async () => {
+          renderLoginPage();
+
+          fillInput();
+          fireEvent.click(screen.getByText('로그인'));
+
+          await waitFor(() => {
+            expect(navigate).toBeCalledWith('/');
+          });
+        });
+      });
+    });
+
+    context('회원가입 버튼을 누를 경우', () => {
+      const currentPath = '/login';
+      beforeEach(() => {
+        location = {
+          state: {
+            previousPath: null,
+          },
+          pathname: currentPath,
+        };
+
+        jest.clearAllMocks();
+      });
+
+      it('회원가입 화면 주소로 navigate, 이때 현재 페이지의 주소를 state로 같이 전달', () => {
+        renderLoginPage();
+
+        fireEvent.click(screen.getByText('회원가입'));
+        expect(navigate).toBeCalledWith('/signup', {
+          state: {
+            previousPath: currentPath,
+          },
         });
       });
     });

--- a/src/pages/NoticesPage.test.jsx
+++ b/src/pages/NoticesPage.test.jsx
@@ -1,21 +1,29 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import context from 'jest-plugin-context';
 import NoticesPage from './NoticesPage';
 
+let location;
 const navigate = jest.fn();
 jest.mock('react-router-dom', () => ({
+  useLocation: () => (
+    location
+  ),
   useNavigate: () => (
     navigate
   ),
 }));
 
-let notices;
-let serverError;
+let noticesAll;
+const noticeStateToShow = 'all';
 const fetchNotices = jest.fn();
+const closeSelectNoticeMode = jest.fn();
+let serverError;
 jest.mock('../hooks/useNoticeStore', () => () => ({
-  notices,
-  serverError,
+  noticesAll,
+  noticeStateToShow,
   fetchNotices,
+  closeSelectNoticeMode,
+  serverError,
 }));
 
 describe('NoticesPage', () => {
@@ -25,36 +33,70 @@ describe('NoticesPage', () => {
     ));
   }
 
-  context('알림 목록 조회 페이지에 접속했을 경우', () => {
-    context('로그인하지 않았을 경우', () => {
+  context('알림 목록 조회 페이지에', () => {
+    context('로그인하지 않고 접속하는 경우', () => {
       beforeEach(() => {
         localStorage.setItem('accessToken', JSON.stringify(''));
 
-        notices = [];
+        location = {
+          state: null,
+        };
+
+        noticesAll = [];
         serverError = '';
+
+        jest.clearAllMocks();
       });
 
       it('로그인 페이지로 navigate하는 함수 호출', () => {
-        jest.clearAllMocks();
         renderNoticesPage();
 
         expect(navigate).toBeCalledWith('/login');
       });
     });
 
-    context('로그인했을 경우', () => {
+    context('로그인한 상태로 접속해', () => {
       beforeEach(() => {
-        localStorage.setItem('accessToken', JSON.stringify('USER ID 1'));
-
-        notices = [];
-        serverError = '';
+        localStorage.setItem('accessToken', JSON.stringify('TOKEN'));
       });
 
-      it('웹 서버로부터 사용자의 알림 데이터를 요청하는 fetchNotice 함수 호출', () => {
-        jest.clearAllMocks();
-        renderNoticesPage();
+      context('출력되는 화면에서 뒤로가기 버튼을 눌렀을 경우', () => {
+        context('이전에 접속했었던 화면의 경로가 존재할 경우', () => {
+          const previousPath = '/wrtie';
+          beforeEach(() => {
+            location = {
+              state: {
+                previousPath,
+              },
+            };
 
-        expect(fetchNotices).toBeCalled();
+            jest.clearAllMocks();
+          });
+
+          it('접속하기 이전의 주소로 navigate', () => {
+            renderNoticesPage();
+
+            fireEvent.click(screen.getByText('뒤로가기'));
+            expect(navigate).toBeCalledWith(previousPath);
+          });
+        });
+
+        context('주소로 직접 접근했었을 경우', () => {
+          beforeEach(() => {
+            location = {
+              state: null,
+            };
+
+            jest.clearAllMocks();
+          });
+
+          it('홈 화면 주소로 navigate', () => {
+            renderNoticesPage();
+
+            fireEvent.click(screen.getByText('뒤로가기'));
+            expect(navigate).toBeCalledWith('/');
+          });
+        });
       });
     });
   });

--- a/src/pages/PostFormPage.test.jsx
+++ b/src/pages/PostFormPage.test.jsx
@@ -2,151 +2,112 @@ import {
   fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 import context from 'jest-plugin-context';
+import ReactModal from 'react-modal';
 import PostFormPage from './PostFormPage';
 
+let location;
 const navigate = jest.fn();
 jest.mock('react-router-dom', () => ({
+  useLocation: () => (
+    location
+  ),
   useNavigate: () => (
     navigate
   ),
 }));
 
-let gameExercise;
-let gameDate;
-let gamePlace;
-let gameTargetMemberCount;
-let postDetail;
-let formErrors;
-let serverErrors;
-const changeGameExercise = jest.fn();
-const changeGameDate = jest.fn();
-const changeGameStartTimeAmPm = jest.fn();
-const changeGameStartHour = jest.fn();
-const changeGameStartMinute = jest.fn();
-const changeGameEndTimeAmPm = jest.fn();
-const changeGameEndHour = jest.fn();
-const changeGameEndMinute = jest.fn();
-const changeGamePlace = jest.fn();
-const changeGameTargetMemberCount = jest.fn();
-const changePostDetail = jest.fn();
-let createPost;
 const clearStates = jest.fn();
+const resetForm = jest.fn();
+const formErrors = {};
+let createPost;
 jest.mock('../hooks/usePostFormStore', () => () => ({
-  gameExercise,
-  gameDate,
-  gamePlace,
-  gameTargetMemberCount,
-  postDetail,
-  formErrors,
-  serverErrors,
-  changeGameExercise,
-  changeGameDate,
-  changeGameStartTimeAmPm,
-  changeGameStartHour,
-  changeGameStartMinute,
-  changeGameEndTimeAmPm,
-  changeGameEndHour,
-  changeGameEndMinute,
-  changeGamePlace,
-  changeGameTargetMemberCount,
-  changePostDetail,
-  createPost,
   clearStates,
+  resetForm,
+  formErrors,
+  createPost,
 }));
 
 describe('PostFormPage', () => {
-  // TODO: 게시글 수정 기능을 추가할 때는 fetchPost, fetchGame, fetchMember로
-  //   게시글의 내용을 가져오는 동작을 전달하는지 검증해야 함
-  //   근데 수정할 때는 참가자 목록이 보여야 하네?
-
-  const renderPostFormPage = () => {
+  function renderPostFormPage() {
     render((
       <PostFormPage />
     ));
-  };
+  }
 
-  context('게시글 작성하기 페이지에 접속해 각 입력 폼의 내용을 수정하면', () => {
-    beforeEach(() => {
-      gameExercise = '';
-      gameDate = new Date('2022-11-23T00:00:00.000Z');
-      gamePlace = '';
-      gameTargetMemberCount = 0;
-      postDetail = '';
-      formErrors = {};
-      serverErrors = {};
-    });
+  context('게시글 작성 페이지에서', () => {
+    context('내용 입력을 정상적으로 마친 상태에서 작성하기 버튼을 누르면', () => {
+      beforeEach(() => {
+        location = {
+          state: null,
+        };
 
-    it('입력되는 내용을 상태로 저장하는 Store의 메서드 호출', () => {
-      renderPostFormPage();
-
-      fireEvent.change(screen.getByLabelText(/종목/), {
-        target: { value: '야구' },
+        const expectedPostId = 99;
+        createPost = jest.fn(() => expectedPostId);
       });
-      expect(changeGameExercise).toBeCalledWith('야구');
 
-      fireEvent.change(screen.getByLabelText(/날짜/), {
-        target: { value: '2022년 11월 24일' },
-      });
-      expect(changeGameDate)
-        .toBeCalledWith(new Date('2022-11-24T00:00:00.000Z'));
-
-      fireEvent.click(screen.getByLabelText(/시작 오후/));
-      expect(changeGameStartTimeAmPm).toBeCalledWith('pm');
-
-      fireEvent.change(screen.getByLabelText(/start hour/), {
-        target: { value: '05' },
-      });
-      expect(changeGameStartHour).toBeCalledWith('05');
-
-      fireEvent.change(screen.getByLabelText(/start minute/), {
-        target: { value: '20' },
-      });
-      expect(changeGameStartMinute).toBeCalledWith('20');
-
-      fireEvent.click(screen.getByLabelText(/종료 오전/));
-      expect(changeGameEndTimeAmPm).toBeCalledWith('am');
-
-      fireEvent.change(screen.getByLabelText(/end hour/), {
-        target: { value: '12' },
-      });
-      expect(changeGameEndHour).toBeCalledWith('12');
-
-      fireEvent.change(screen.getByLabelText(/end minute/), {
-        target: { value: '30' },
-      });
-      expect(changeGameEndMinute).toBeCalledWith('30');
-
-      fireEvent.change(screen.getByLabelText(/장소/), {
-        target: { value: '고척스카이돔' },
-      });
-      expect(changeGamePlace).toBeCalledWith('고척스카이돔');
-
-      fireEvent.change(screen.getByLabelText(/모집 인원/), {
-        target: { value: 20 },
-      });
-      expect(changeGameTargetMemberCount).toBeCalledWith('20');
-
-      fireEvent.change(screen.getByLabelText(/상세 내용/), {
-        target: { value: '상세 내용' },
-      });
-      expect(changePostDetail).toBeCalledWith('상세 내용');
-    });
-
-    context('작성하기 버튼을 누르면', () => {
-      it('게시글 생성 API 요청을 호출하는 Store의 메서드 호출한 뒤, '
-        + '생성된 게시글 아이디가 반환되면 '
-        + 'Store의 상태를 비우고 게시글 목록 보기 페이지로 navigate', async () => {
-        jest.clearAllMocks();
-        const createdPostId = 10;
-        createPost = jest.fn(() => createdPostId);
-
+      // TODO: 게시글 목록 페이지가 아니라
+      //   작성한 게시글의 상세 내용 페이지로 navigate되도록 수정하는 게 좋겠다.
+      it('게시글 목록 페이지로 navigate', async () => {
         renderPostFormPage();
 
         fireEvent.click(screen.getByText('작성하기'));
         await waitFor(() => {
-          expect(createPost).toBeCalled();
-          expect(clearStates).toBeCalled();
-          expect(navigate).toBeCalledWith('/posts/list');
+          expect(navigate).toBeCalledWith('/posts/list', {
+            state: {
+              postStatus: 'created',
+            },
+          });
+        });
+      });
+    });
+
+    context('뒤로가기 버튼을 누르고, 동작 수행 재확인 Modal에서 예 버튼을 눌렀을 경우', () => {
+      beforeEach(() => {
+        ReactModal.setAppElement('*');
+      });
+
+      context('이전에 접속했었던 화면의 경로가 존재할 경우', () => {
+        const previousPath = '/posts/3';
+        beforeEach(() => {
+          location = {
+            state: {
+              previousPath,
+            },
+          };
+
+          jest.clearAllMocks();
+        });
+
+        it('접속하기 이전의 주소로 navigate', async () => {
+          renderPostFormPage();
+
+          fireEvent.click(screen.getByText('뒤로가기'));
+          screen.getByText('정말로 게시글 작성을 중단하시겠습니까?');
+          fireEvent.click(screen.getByText('예'));
+          await waitFor(() => {
+            expect(navigate).toBeCalledWith(previousPath);
+          });
+        });
+      });
+
+      context('주소로 직접 접근했었을 경우', () => {
+        beforeEach(() => {
+          location = {
+            state: null,
+          };
+
+          jest.clearAllMocks();
+        });
+
+        it('홈 화면 주소로 navigate', async () => {
+          renderPostFormPage();
+
+          fireEvent.click(screen.getByText('뒤로가기'));
+          screen.getByText('정말로 게시글 작성을 중단하시겠습니까?');
+          fireEvent.click(screen.getByText('예'));
+          await waitFor(() => {
+            expect(navigate).toBeCalledWith('/');
+          });
         });
       });
     });

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -22,8 +22,7 @@ export default function PostPage() {
     });
   };
 
-  // TODO: 체험 계정 선택하기 페이지로 이동시키기
-
+  // TODO: 체험 계정 선택하기는 체험 계정 선택하기 페이지로 이동해야 함
   const navigateSelectTrialAccount = () => {
     navigate('/login', {
       state: {

--- a/src/pages/PostPage.test.jsx
+++ b/src/pages/PostPage.test.jsx
@@ -2,16 +2,15 @@ import {
   fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 import context from 'jest-plugin-context';
+import ReactModal from 'react-modal';
 import PostPage from './PostPage';
 
-let postId;
+let location;
 const navigate = jest.fn();
 jest.mock('react-router-dom', () => ({
-  useLocation: () => ({
-    state: {
-      postId,
-    },
-  }),
+  useLocation: () => (
+    location
+  ),
   useNavigate: () => (
     navigate
   ),
@@ -25,43 +24,29 @@ jest.mock('../hooks/usePostStore', () => () => ({
   fetchPost,
   deletePost,
 }));
-
 let game;
-let fetchGame;
+const gameId = 1;
+const fetchGame = jest.fn(() => gameId);
 jest.mock('../hooks/useGameStore', () => () => ({
   game,
   fetchGame,
 }));
-
-let place;
-let fetchPlace;
+const fetchPlace = jest.fn();
 jest.mock('../hooks/usePlaceStore', () => () => ({
-  place,
   fetchPlace,
 }));
-
-let members;
-let applicants;
-let registerErrorCodeAndMessage;
 const fetchMembers = jest.fn();
 const fetchApplicants = jest.fn();
-let registerToGame;
-const cancelRegisterToGame = jest.fn();
-const cancelParticipateToGame = jest.fn();
-const acceptRegister = jest.fn();
-const rejectRegister = jest.fn();
 jest.mock('../hooks/useRegisterStore', () => () => ({
-  members,
-  applicants,
-  registerErrorCodeAndMessage,
   fetchMembers,
   fetchApplicants,
-  registerToGame,
-  cancelRegisterToGame,
-  cancelParticipateToGame,
-  acceptRegister,
-  rejectRegister,
 }));
+
+jest.mock('../components/PostGame', () => jest.fn());
+jest.mock('../components/PostContent', () => jest.fn());
+jest.mock('../components/PostPlace', () => jest.fn());
+jest.mock('../components/PostGameMembers', () => jest.fn());
+jest.mock('../components/PostGameApplicants', () => jest.fn());
 
 describe('PostPage', () => {
   function renderPostPage() {
@@ -70,421 +55,83 @@ describe('PostPage', () => {
     ));
   }
 
-  context('로그인하지 않았을 경우', () => {
-    context('운동 모집 게시글 상세 정보 페이지에 접속하면', () => {
+  const pathname = '/posts/1';
+
+  beforeEach(() => {
+    location = {
+      pathname,
+      state: {
+        postId: 1,
+      },
+    };
+    post = {
+      isAuthor: false,
+    };
+    game = {
+      placeId: 1,
+    };
+  });
+
+  context('게시글 상세 정보 페이지에', () => {
+    context('접속해서 뒤로가기 버튼을 누를 경우', () => {
+      it('게시글 목록 페이지로 이동하는 navigate 함수 호출', () => {
+        renderPostPage();
+
+        fireEvent.click(screen.getByText('뒤로가기'));
+        expect(navigate).toBeCalledWith('/posts/list');
+      });
+    });
+
+    context('로그인하지 않은 상태로 접속해', () => {
       beforeEach(() => {
         localStorage.setItem('accessToken', JSON.stringify(''));
-
-        postId = 1;
-
-        post = {
-          id: 1,
-          hits: 15,
-          authorName: '작성자',
-          authorPhoneNumber: '010-6877-2291',
-          detail: '게시글 상세 정보 내용입니다.',
-          isAuthor: false,
-        };
-        game = {
-          id: 1,
-          type: '농구',
-          date: '2022년 12월 23일 20:00~22:00',
-          place: '인천삼산체육관',
-          currentMemberCount: 2,
-          targetMemberCount: 12,
-          registerId: -1,
-          registerStatus: 'none',
-        };
-        members = [
-          {
-            id: 1,
-            name: '작성자',
-            gender: '남성',
-            phoneNumber: '010-6877-2291',
-          },
-        ];
-        registerErrorCodeAndMessage = {};
       });
 
-      it('로그인 안내 메세지, 버튼 출력', async () => {
-        jest.clearAllMocks();
-        fetchGame = jest.fn();
+      // TODO: 체험 계정 선택하기는 체험 계정 선택하기 페이지로 이동해야 함
+      context('로그인하기/체험 계정 선택하기 버튼을 눌렀을 경우', () => {
+        it('로그인 화면으로 이동하는 navigate 함수 호출, 현재 경로를 state로 같이 전달', () => {
+          renderPostPage();
 
-        renderPostPage();
-
-        await waitFor(() => {
-          screen.getByText('운동에 신청하려면 로그인해주세요.');
-          screen.getByText('로그인하기');
-          screen.getByText('체험 계정 선택하기');
-        });
-      });
-
-      it('로그인 버튼 클릭 시 로그인 페이지로 이동하는 navigate 함수 호출', async () => {
-        jest.clearAllMocks();
-        fetchGame = jest.fn();
-
-        renderPostPage();
-
-        await waitFor(() => {
           fireEvent.click(screen.getByText('로그인하기'));
-          expect(navigate).toBeCalledWith('/login');
+          expect(navigate).toBeCalledWith('/login', {
+            state: {
+              previousPath: pathname,
+            },
+          });
+          fireEvent.click(screen.getByText('체험 계정 선택하기'));
+          expect(navigate).toBeCalledWith('/login', {
+            state: {
+              previousPath: pathname,
+            },
+          });
         });
       });
-
-      // TODO: 체험 계정 선택 시 체험 계정 선택 링크로 이동하는 함수 호출 검증
     });
-  });
 
-  context('게시글 작성자가 아닌 경우', () => {
-    context('운동 모집 게시글 상세 정보 페이지에 접속하면', () => {
+    context('게시글 작성자가 로그인한 상태로 접속해', () => {
       beforeEach(() => {
-        localStorage.setItem('accessToken', JSON.stringify('ACCESS TOKEN'));
-
-        postId = 1;
-
+        ReactModal.setAppElement('*');
+        localStorage.setItem('accessToken', JSON.stringify('TOKEN'));
         post = {
-          id: 1,
-          hits: 15,
-          authorName: '작성자',
-          authorPhoneNumber: '010-6877-2291',
-          detail: '게시글 상세 정보 내용입니다.',
-          isAuthor: false,
+          isAuthor: true,
         };
-        game = {
-          id: 1,
-          type: '농구',
-          date: '2022년 12월 23일 20:00~22:00',
-          place: '인천삼산체육관',
-          currentMemberCount: 2,
-          targetMemberCount: 12,
-          registerId: -1,
-          registerStatus: 'none',
-        };
-        members = [
-          {
-            id: 1,
-            name: '작성자',
-            gender: '남성',
-            phoneNumber: '010-6877-2291',
-          },
-        ];
-        registerErrorCodeAndMessage = {};
       });
 
-      it('운동 모집 게시글 상세 정보 상태들을 PostStore, '
-        + 'GameStore, MemberStore에서 순차적으로 fetch', async () => {
-        jest.clearAllMocks();
-        const expectedPostId = 1;
-        const expectedGameId = 1;
-        fetchGame = jest.fn(() => expectedGameId);
+      context('게시글 삭제 버튼을 누르고, 동작 수행 재확인 Modal에서 예 버튼을 눌렀을 경우', () => {
+        it('게시글 목록 화면으로 이동하는 navigate 함수 호출, '
+          + '게시글을 삭제했음을 알리는 상태를 state로 같이 전달', async () => {
+          renderPostPage();
 
-        renderPostPage();
-
-        await waitFor(() => {
-          expect(fetchPost).toBeCalledWith(expectedPostId);
-          expect(fetchGame).toBeCalledWith(expectedPostId);
-          expect(fetchMembers).toBeCalledWith(expectedGameId);
-          expect(fetchApplicants).not.toBeCalled();
-        });
-      });
-    });
-
-    context('게시글에 참가 신청 버튼이 출력되는 상태에서 사용자가 참가 신청 버튼을 누르면', () => {
-      beforeEach(() => {
-        localStorage.setItem('accessToken', JSON.stringify('ACCESS TOKEN'));
-
-        postId = 1;
-
-        post = {
-          id: 1,
-          hits: 15,
-          authorName: '작성자',
-          authorPhoneNumber: '010-6877-2291',
-          detail: '게시글 상세 정보 내용입니다.',
-          isAuthor: false,
-        };
-        game = {
-          id: 1,
-          type: '야구',
-          date: '2022년 09월 30일 14:00~17:00',
-          place: '한화생명이글스파크',
-          currentMemberCount: 1,
-          targetMemberCount: 6,
-          registerId: -1,
-          registerStatus: 'none',
-        };
-        members = [
-          {
-            id: 1,
-            name: '작성자',
-            gender: '남성',
-            phoneNumber: '010-6877-2291',
-          },
-        ];
-        registerErrorCodeAndMessage = {};
-      });
-
-      it('해당 게임에 참가를 신청하는 운동 참가 신청 함수 호출 후, '
-        + '신청 번호를 성공적으로 반환했을 경우 게시글 상세 정보를 순차적으로 fetch', async () => {
-        jest.clearAllMocks();
-        const expectedPostId = 1;
-        const expectedGameId = 1;
-        const expectedApplicationId = 2;
-        registerToGame = jest.fn(() => expectedApplicationId);
-        fetchGame = jest.fn(() => expectedGameId);
-
-        renderPostPage();
-
-        fireEvent.click(screen.getByText('신청'));
-        await waitFor(() => {
-          expect(registerToGame).toBeCalledWith(expectedGameId);
-          expect(fetchPost).nthCalledWith(2, expectedPostId);
-          expect(fetchGame).nthCalledWith(2, expectedPostId);
-          expect(fetchMembers).nthCalledWith(2, expectedGameId);
-          expect(fetchApplicants).not.toBeCalled();
-        });
-      });
-    });
-
-    context('게시글에 참가 신청 취소 버튼이 출력되는 상태에서 사용자가 참가 신청 취소 버튼을 누르면', () => {
-      beforeEach(() => {
-        localStorage.setItem('accessToken', JSON.stringify('ACCESS TOKEN'));
-
-        postId = 1;
-
-        post = {
-          id: 1,
-          hits: 15,
-          authorName: '작성자',
-          authorPhoneNumber: '010-6877-2291',
-          detail: '게시글 상세 정보 내용입니다.',
-          isAuthor: false,
-        };
-        game = {
-          id: 2,
-          type: '수영',
-          date: '2022년 12월 26일 07:00~09:00',
-          place: '박태환수영장',
-          currentMemberCount: 2,
-          targetMemberCount: 6,
-          registerId: 17,
-          registerStatus: 'processing',
-        };
-        members = [
-          {
-            id: 1,
-            name: '작성자',
-            gender: '남성',
-            phoneNumber: '010-6877-2291',
-          },
-          {
-            id: 17,
-            name: '수영 좋아하는 사람',
-            gender: '남성',
-            phoneNumber: '010-5555-5555',
-          },
-        ];
-        registerErrorCodeAndMessage = {};
-      });
-
-      it('해당 신청의 상태를 변경하는 운동 참가 신청 취소 함수 호출 후, '
-      + '게시글 상세 정보를 순차적으로 fetch', async () => {
-        jest.clearAllMocks();
-        const expectedPostId = 1;
-        const expectedGameId = 2;
-        const expectedRegisterId = 17;
-        fetchGame = jest.fn(() => expectedGameId);
-
-        renderPostPage();
-
-        fireEvent.click(screen.getByText('신청취소'));
-        await waitFor(() => {
-          expect(cancelRegisterToGame).toBeCalledWith(expectedRegisterId);
-          expect(fetchPost).nthCalledWith(2, expectedPostId);
-          expect(fetchGame).nthCalledWith(2, expectedPostId);
-          expect(fetchMembers).nthCalledWith(2, expectedGameId);
-          expect(fetchApplicants).not.toBeCalled();
-        });
-      });
-    });
-
-    context('게시글에 참가 취소 버튼이 출력되는 상태에서 사용자가 참가 취소 버튼을 누르면', () => {
-      beforeEach(() => {
-        localStorage.setItem('accessToken', JSON.stringify('ACCESS TOKEN'));
-
-        postId = 1;
-
-        post = {
-          id: 1,
-          hits: 15,
-          authorName: '작성자',
-          authorPhoneNumber: '010-6877-2291',
-          detail: '게시글 상세 정보 내용입니다.',
-          isAuthor: false,
-        };
-        game = {
-          id: 2,
-          type: '양궁',
-          date: '2022년 1월 30일 17:00~19:00',
-          place: '진천국가대표선수촌훈련장 양궁장',
-          currentMemberCount: 2,
-          targetMemberCount: 2,
-          registerId: 20,
-          registerStatus: 'accepted',
-        };
-        members = [
-          {
-            id: 1,
-            name: '작성자',
-            gender: '남성',
-            phoneNumber: '010-6877-2291',
-          },
-          {
-            id: 20,
-            name: '안산',
-            gender: '여성',
-            phoneNumber: '010-8765-4321',
-          },
-        ];
-        registerErrorCodeAndMessage = {};
-      });
-
-      it('해당 신청의 상태를 변경하는 운동 참가 취소 함수 호출 후, '
-      + '게시글 상세 정보를 순차적으로 fetch', async () => {
-        jest.clearAllMocks();
-        const expectedPostId = 1;
-        const expectedGameId = 2;
-        const expectedRegisterId = 20;
-        fetchGame = jest.fn(() => expectedGameId);
-
-        renderPostPage();
-
-        fireEvent.click(screen.getByText('참가취소'));
-        await waitFor(() => {
-          expect(cancelParticipateToGame).toBeCalledWith(expectedRegisterId);
-          expect(fetchPost).nthCalledWith(2, expectedPostId);
-          expect(fetchGame).nthCalledWith(2, expectedPostId);
-          expect(fetchMembers).nthCalledWith(2, expectedGameId);
-          expect(fetchApplicants).not.toBeCalled();
-        });
-      });
-    });
-  });
-
-  context('게시글 작성자인 경우', () => {
-    beforeEach(() => {
-      localStorage.setItem('accessToken', JSON.stringify('ACCESS TOKEN'));
-
-      postId = 1;
-
-      post = {
-        id: 1,
-        hits: 15,
-        authorName: '작성자',
-        authorPhoneNumber: '010-6877-2291',
-        detail: '게시글 상세 정보 내용입니다.',
-        isAuthor: true,
-      };
-      game = {
-        id: 2,
-        type: '육상',
-        date: '2022년 5월 14일 20:00~21:00',
-        place: '잠실종합운동장',
-        currentMemberCount: 1,
-        targetMemberCount: 5,
-        registerId: 4,
-        registerStatus: 'accepted',
-      };
-      members = [
-        {
-          id: 1,
-          name: '작성자',
-          gender: '남성',
-          phoneNumber: '010-6877-2291',
-        },
-      ];
-      applicants = [
-        {
-          id: 3,
-          name: '이봉주',
-          gender: '남성',
-          phoneNumber: '010-2424-2424',
-        },
-      ];
-      registerErrorCodeAndMessage = {};
-    });
-
-    it('운동 모집 게시글 상세 정보 및 신청자 정보 상태들을 PostStore, '
-    + 'GameStore, MemberStore에서 순차적으로 fetch', async () => {
-      jest.clearAllMocks();
-      const expectedPostId = 1;
-      const expectedGameId = 2;
-      fetchGame = jest.fn(() => expectedGameId);
-
-      renderPostPage();
-
-      await waitFor(() => {
-        expect(fetchPost).toBeCalledWith(expectedPostId);
-        expect(fetchGame).toBeCalledWith(expectedPostId);
-        expect(fetchMembers).toBeCalledWith(expectedGameId);
-        expect(fetchApplicants).toBeCalledWith(expectedGameId);
-      });
-    });
-
-    context('신청자에 대해 수락 버튼을 눌렀을 경우', () => {
-      it('참가 신청 수락 함수 호출 후, 게시글 상세 정보를 순차적으로 fetch', async () => {
-        jest.clearAllMocks();
-        const expectedPostId = 1;
-        const expectedGameId = 2;
-        const expectedRegisterId = 3;
-        fetchGame = jest.fn(() => expectedGameId);
-
-        renderPostPage();
-
-        fireEvent.click(screen.getByText('수락'));
-        await waitFor(() => {
-          expect(acceptRegister).toBeCalledWith(expectedRegisterId);
-          expect(fetchPost).nthCalledWith(2, expectedPostId);
-          expect(fetchGame).nthCalledWith(2, expectedPostId);
-          expect(fetchMembers).nthCalledWith(2, expectedGameId);
-          expect(fetchApplicants).nthCalledWith(2, expectedGameId);
-        });
-      });
-    });
-
-    context('신청자에 대해 거절 버튼을 눌렀을 경우', () => {
-      it('참가 신청 거절 함수 호출 후, 게시글 상세 정보를 순차적으로 fetch', async () => {
-        jest.clearAllMocks();
-        const expectedPostId = 1;
-        const expectedGameId = 2;
-        const expectedRegisterId = 3;
-        fetchGame = jest.fn(() => expectedGameId);
-
-        renderPostPage();
-
-        fireEvent.click(screen.getByText('거절'));
-        await waitFor(() => {
-          expect(rejectRegister).toBeCalledWith(expectedRegisterId);
-          expect(fetchPost).nthCalledWith(2, expectedPostId);
-          expect(fetchGame).nthCalledWith(2, expectedPostId);
-          expect(fetchMembers).nthCalledWith(2, expectedGameId);
-          expect(fetchApplicants).nthCalledWith(2, expectedGameId);
-        });
-      });
-    });
-
-    // TODO: 게시글 수정하기 동작과 관련된 테스트 코드는 여기에 추가되어야 함
-
-    context('게시글 삭제하기 버튼을 눌렀을 경우', () => {
-      it('게시글 삭제 함수 호출', async () => {
-        jest.clearAllMocks();
-        fetchGame = jest.fn();
-        renderPostPage();
-
-        fireEvent.click(screen.getByText('삭제하기'));
-        await waitFor(() => {
-          expect(deletePost).toBeCalled();
-          expect(navigate).toBeCalledWith('/posts/list');
+          fireEvent.click(screen.getByText('삭제하기'));
+          screen.getByText('정말로 게시글을 삭제하시겠습니까?');
+          fireEvent.click(screen.getByText('예'));
+          await waitFor(() => {
+            expect(navigate).toBeCalledWith('/posts/list', {
+              state: {
+                postStatus: 'deleted',
+              },
+            });
+          });
         });
       });
     });

--- a/src/pages/SignUpPage.test.jsx
+++ b/src/pages/SignUpPage.test.jsx
@@ -1,0 +1,129 @@
+import {
+  fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import context from 'jest-plugin-context';
+import SignUpPage from './SignUpPage';
+
+let location;
+const navigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useLocation: () => (
+    location
+  ),
+  useNavigate: () => (
+    navigate
+  ),
+}));
+
+const clearSignUpError = jest.fn();
+let signUp;
+let login;
+jest.mock('../hooks/useUserStore', () => () => ({
+  clearSignUpError,
+  signUp,
+  login,
+}));
+
+describe('SignUpPage', () => {
+  function renderSignUpPage() {
+    render((
+      <SignUpPage />
+    ));
+  }
+
+  const previousPath = '/login';
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', JSON.stringify(''));
+
+    location = {
+      state: {
+        previousPath,
+      },
+    };
+  });
+
+  context('회원가입 페이지에서', () => {
+    context('뒤로가기 버튼을 누르면', () => {
+      context('이전에 접속했었던 화면의 경로가 존재할 경우', () => {
+        it('접속하기 이전의 주소로 navigate', () => {
+          renderSignUpPage();
+
+          fireEvent.click(screen.getByText('뒤로가기'));
+          expect(navigate).toBeCalledWith(previousPath);
+        });
+      });
+
+      context('주소로 직접 접근했었을 경우', () => {
+        beforeEach(() => {
+          location = {
+            state: null,
+          };
+        });
+
+        it('홈 화면 주소로 navigate', () => {
+          renderSignUpPage();
+
+          fireEvent.click(screen.getByText('뒤로가기'));
+          expect(navigate).toBeCalledWith('/');
+        });
+      });
+    });
+
+    context('내용 입력을 정상적으로 마친 상태에서 회원가입 버튼을 누르면', () => {
+      const name = '황인우';
+      const username = 'hsjkdss228';
+      const password = 'Password!1';
+      const confirmPassword = 'Password!1';
+      const gender = '남성';
+      const phoneNumber = '01098765432';
+      const verifiedAccessToken = 'TOKEN';
+      beforeEach(() => {
+        signUp = jest.fn(() => name);
+        login = jest.fn(() => verifiedAccessToken);
+      });
+
+      it('회원가입을 마치고, 해당 정보로 로그인한 뒤, 회원가입 완료 페이지로 navigate', async () => {
+        renderSignUpPage();
+
+        fireEvent.change(screen.getByLabelText('성함'), {
+          target: { value: name },
+        });
+        fireEvent.change(screen.getByLabelText('아이디'), {
+          target: { value: username },
+        });
+        fireEvent.change(screen.getByLabelText('비밀번호'), {
+          target: { value: password },
+        });
+        fireEvent.change(screen.getByLabelText('비밀번호 확인'), {
+          target: { value: confirmPassword },
+        });
+        fireEvent.click(screen.getByLabelText('남성'));
+        fireEvent.change(screen.getByLabelText('전화번호'), {
+          target: { value: phoneNumber },
+        });
+
+        fireEvent.click(screen.getByText('회원가입'));
+        await waitFor(() => {
+          expect(signUp).toBeCalledWith({
+            name,
+            username,
+            password,
+            confirmPassword,
+            gender,
+            phoneNumber,
+          });
+          expect(login).toBeCalledWith({
+            username,
+            password,
+          });
+          expect(navigate).toBeCalledWith('/welcome', {
+            state: {
+              enrolledName: name,
+            },
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/pages/WelcomePage.test.jsx
+++ b/src/pages/WelcomePage.test.jsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import context from 'jest-plugin-context';
+import WelcomePage from './WelcomePage';
+
+let location;
+const navigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useLocation: () => (
+    location
+  ),
+  useNavigate: () => (
+    navigate
+  ),
+}));
+
+describe('WelcomePage', () => {
+  function renderWelcomePage() {
+    render((
+      <WelcomePage />
+    ));
+  }
+
+  beforeEach(() => {
+    location = {
+      state: {
+        enrolledName: '방금 회원가입한 회원',
+      },
+    };
+  });
+
+  context('회원가입 페이지에서', () => {
+    context('홈으로 버튼을 누르면', () => {
+      it('홈 화면으로 navigate', () => {
+        renderWelcomePage();
+
+        fireEvent.click(screen.getByText('홈으로'));
+        expect(navigate).toBeCalledWith('/', {
+          state: {
+            previousPath: '/',
+          },
+        });
+      });
+    });
+
+    context('운동 모집하기 버튼을 누르면', () => {
+      it('게시글 작성 화면으로 navigate', () => {
+        renderWelcomePage();
+
+        fireEvent.click(screen.getByText('운동 모집하기'));
+        expect(navigate).toBeCalledWith('/write', {
+          state: {
+            previousPath: '/',
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/services/NoticeApiService.js
+++ b/src/services/NoticeApiService.js
@@ -30,17 +30,6 @@ export default class NoticeApiService {
     await axios.patch(url);
   }
 
-  async fetchUnreadNoticeCount() {
-    const url = `${apiBaseUrl}/notice-count`;
-    const { data } = await axios.get(url, {
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
-      },
-      params: { status: 'unread' },
-    });
-    return data;
-  }
-
   async readSelectedNotices({ selectedNoticeIds }) {
     const url = `${apiBaseUrl}/notices`;
     await axios.patch(url, { ids: selectedNoticeIds }, {
@@ -53,6 +42,17 @@ export default class NoticeApiService {
     await axios.patch(url, { ids: selectedNoticeIds }, {
       params: { status: 'deleted' },
     });
+  }
+
+  async fetchUnreadNoticeCount() {
+    const url = `${apiBaseUrl}/notice-count`;
+    const { data } = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+      params: { status: 'unread' },
+    });
+    return data;
   }
 }
 

--- a/src/stores/GameStore.js
+++ b/src/stores/GameStore.js
@@ -15,8 +15,7 @@ export default class GameStore extends Store {
       this.game = data;
       return this.game.id;
     } catch (error) {
-      const { errorMessage } = error.response.data;
-      this.gameServerError = errorMessage;
+      this.gameServerError = error.response.data;
       return '';
     }
   }

--- a/src/stores/NoticeStore.test.js
+++ b/src/stores/NoticeStore.test.js
@@ -1,88 +1,283 @@
 import context from 'jest-plugin-context';
+import { waitFor } from '@testing-library/react';
 import NoticeStore from './NoticeStore';
 
 import { noticeApiService } from '../services/NoticeApiService';
 
 describe('NoticeStore', () => {
   let noticeStore;
+
+  let spyInitNoticesDetailState;
+  let spyInitSelectedNotices;
+  let spyFetchNotices;
   let spyReadNotice;
+  let spyReadSelectedNotices;
+  let spyDeleteSelectedNotices;
+  let spyFetchUnreadNoticeCount;
 
   beforeEach(() => {
     noticeStore = new NoticeStore();
+    noticeApiService.setAccessToken('userId 1');
+
+    spyInitNoticesDetailState = jest.spyOn(noticeStore, 'initNoticesDetailState');
+    spyInitSelectedNotices = jest.spyOn(noticeStore, 'initSelectedNotices');
+
+    spyFetchNotices = jest.spyOn(noticeStore, 'fetchNotices');
     spyReadNotice = jest.spyOn(noticeApiService, 'readNotice');
+    spyReadSelectedNotices = jest.spyOn(noticeApiService, 'readSelectedNotices');
+    spyDeleteSelectedNotices = jest.spyOn(noticeApiService, 'deleteSelectedNotices');
+    spyFetchUnreadNoticeCount = jest.spyOn(noticeStore, 'fetchUnreadNoticeCount');
+
     jest.clearAllMocks();
   });
 
-  context('API 서버에 접속한 사용자의 알림 목록을 요청할 경우', () => {
-    it('웹 서버에서 응답으로 전달된 알림 목록을 상태로 저장', async () => {
-      noticeApiService.setAccessToken('userId 1');
-      await noticeStore.fetchNotices();
+  // TODO: initNoticesDetailState, initSelectedNotices 테스트 작성
 
-      const {
-        notices,
-        serverError,
-      } = noticeStore;
+  context('알림 선택하기 모드 상태를 변경하는 경우', () => {
+    it('알림 선택하기 모드 상태를 반대로 변경, '
+      + '알림 선택하기 모드를 끄는 경우에는 선택된 알림 목록 상태 배열을 초기화', () => {
+      expect(noticeStore.noticeStateToShow).toBe('all');
+      expect(noticeStore.selectNoticeMode).toBe(false);
 
-      expect(notices.length).toBe(2);
-      expect(notices[0].createdAt).toBe('6시간 전');
-      expect(notices[1].title).toContain('새로운 참가 신청이 있습니다');
-      expect(serverError).toBeFalsy();
+      noticeStore.toggleSelectNoticeMode();
+      expect(noticeStore.selectNoticeMode).toBe(true);
+
+      noticeStore.toggleSelectNoticeMode();
+      expect(noticeStore.selectNoticeMode).toBe(false);
+      expect(spyInitSelectedNotices).toBeCalled();
     });
   });
 
-  context('알림의 상태를 읽음 상태로 변경 요청이 들어오는 경우', () => {
-    context('알림이 읽지 않음 상태였다면', () => {
-      beforeEach(() => {
-        noticeStore.notices = [
-          {
-            id: 1,
-            status: 'unread',
-            createdAt: '6시간 전',
-            title: '내가 신청한 운동 모집 게시글의 작성자가 신청을 수락했습니다.',
-            detail: '신청한 게임 시간',
-          },
-          {
-            id: 2,
-            status: 'read',
-            createdAt: '12시간 전',
-            title: '내가 작성한 운동 모집 게시글에 새로운 참가 신청이 있습니다.',
-            detail: '등록한 신청자: 황인우',
-          },
-        ];
-      });
+  context('모든 알림 조회하기 모드 상태를 활성화하는 경우', () => {
+    it('출력할 알림 상태를 모든 알림 조회하기로 변경한 뒤 '
+      + '서버에 알림 목록을 요청하는 함수 호출', async () => {
+      expect(noticeStore.noticeStateToShow).toBe('all');
+      await noticeStore.showAll();
 
-      it('알림을 읽음 상태로 변경하는 API 요청 호출', async () => {
-        const targetIndex = 0;
-        await noticeStore.readNotice(targetIndex);
-        const expectedNoticeId = 1;
-        expect(spyReadNotice).toBeCalledWith(expectedNoticeId);
+      expect(noticeStore.noticeStateToShow).toBe('all');
+      expect(spyFetchNotices).toBeCalled();
+    });
+  });
+
+  context('읽지 않은 알림만 조회하기 모드 상태를 활성화하는 경우', () => {
+    it('출력할 알림 상태를 읽지 않은 알림만 조회하기로 변경한 뒤 '
+      + '서버에 알림 목록을 요청하는 함수 호출', async () => {
+      expect(noticeStore.noticeStateToShow).toBe('all');
+      await noticeStore.showUnreadOnly();
+
+      expect(noticeStore.noticeStateToShow).toBe('unread');
+      expect(spyFetchNotices).toBeCalled();
+    });
+  });
+
+  context('알림 목록 페이지에 접속했을 때는 알림 선택하기 상태를 비활성화시키는 함수를 호출하는데, 이 경우', () => {
+    beforeEach(() => {
+      noticeStore.toggleSelectNoticeMode();
+    });
+
+    it('알림 선택하기 상태가 비활성화 상태로 변경됨', () => {
+      expect(noticeStore.selectNoticeMode).toBeTruthy();
+
+      noticeStore.closeSelectNoticeMode();
+      expect(noticeStore.selectNoticeMode).toBeFalsy();
+    });
+  });
+
+  context('서버에 알림 목록을 요청할 경우', () => {
+    context('정상적인 Access Token으로 요청할 경우', () => {
+      it('응답으로 전달받은 알림 목록을 이용해 전체 알림 목록 배열과 읽지 않은 알림 목록 배열을 생성해 상태로 저장, '
+      + '상세 정보를 조회 중인 알림 상태 배열과 알림 선택 상태 배열은 초기화', async () => {
+        await noticeStore.fetchNotices();
+
+        expect(noticeStore.noticesAll.length).toBe(2);
+        expect(noticeStore.noticesUnread.length).toBe(1);
+        expect(spyInitNoticesDetailState).toBeCalled();
+        expect(spyInitSelectedNotices).toBeCalled();
       });
     });
 
-    context('알림이 읽음 상태였다면', () => {
+    context('잘못된 Access Token으로 요청할 경우', () => {
       beforeEach(() => {
-        noticeStore.notices = [
-          {
-            id: 1,
-            status: 'unread',
-            createdAt: '6시간 전',
-            title: '내가 신청한 운동 모집 게시글의 작성자가 신청을 수락했습니다.',
-            detail: '신청한 게임 시간',
-          },
-          {
-            id: 2,
-            status: 'read',
-            createdAt: '12시간 전',
-            title: '내가 작성한 운동 모집 게시글에 새로운 참가 신청이 있습니다.',
-            detail: '등록한 신청자: 황인우',
-          },
-        ];
+        noticeApiService.setAccessToken('Wrong Access Token');
       });
 
-      it('알림을 읽음 상태로 변경하는 API 요청을 호출하지 않음', async () => {
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await noticeStore.fetchNotices();
+
+        expect(noticeStore.serverError).toBe('Authentication Error');
+        expect(noticeStore.noticesAll.length).toBe(0);
+        expect(noticeStore.noticesUnread.length).toBe(0);
+        expect(spyInitNoticesDetailState).not.toBeCalled();
+        expect(spyInitSelectedNotices).not.toBeCalled();
+      });
+    });
+  });
+
+  context('모든 알림 선택, 모든 알림 선택 해제 시에는', () => {
+    beforeEach(async () => {
+      await noticeStore.fetchNotices();
+    });
+
+    context('사용될 알림 목록 배열은', () => {
+      context('모든 알림 조회하기 모드 상태가 활성화되어 있는 경우에는', () => {
+        it('모든 알림 목록 배열을 사용', () => {
+          noticeStore.showAll();
+          expect(noticeStore.chooseArrayForSelectionByStateToShow().length)
+            .toBe(2);
+        });
+      });
+
+      context('읽지 않은 알림만 조회하기 모드 상태가 활성화되어 있는 경우에는', () => {
+        it('모든 알림 목록 배열을 사용', () => {
+          noticeStore.showUnreadOnly();
+          expect(noticeStore.chooseArrayForSelectionByStateToShow().length)
+            .toBe(1);
+        });
+      });
+    });
+
+    context('모든 알림을 선택하면', () => {
+      it('선택된 알림 목록 배열에 모든 알림들의 id를 추가', () => {
+        noticeStore.selectAllNotices();
+
+        noticeStore.selectedNotices.forEach((selectedNoticeId, index) => {
+          expect(selectedNoticeId).toBe(noticeStore.noticesAll[index].id);
+        });
+      });
+    });
+
+    context('모든 알림을 선택 해제하면', () => {
+      it('선택된 알림 목록 배열의 모든 index를 빈 값으로 설정', () => {
+        noticeStore.deselectAllNotices();
+
+        noticeStore.selectedNotices.forEach((selectedNoticeId) => {
+          expect(selectedNoticeId).toBe('');
+        });
+      });
+    });
+  });
+
+  context('특정 알림 선택/선택 해제 시에는', () => {
+    beforeEach(async () => {
+      await noticeStore.fetchNotices();
+      noticeStore.toggleSelectNoticeMode();
+    });
+
+    const targetIndex = 0;
+    const anotherIndex = 1;
+    const targetId = 1;
+    const anotherId = 2;
+
+    context('해당 알림이 선택되어 있지 않은 상태인 경우', () => {
+      it('해당 알림의 선택 상태를 선택되어 있는 상태로 변경', () => {
+        noticeStore.selectNotice({ targetIndex, targetId });
+
+        expect(noticeStore.selectedNotices[targetIndex]).toBe(targetId);
+        expect(noticeStore.selectedNotices[anotherIndex]).toBeFalsy();
+      });
+    });
+
+    context('해당 알림이 선택되어 있는 상태인 경우', () => {
+      beforeEach(() => {
+        noticeStore.selectNotice({ targetIndex, targetId });
+      });
+
+      it('해당 알림의 선택 상태를 선택되어 있지 않은 상태로 변경', () => {
+        noticeStore.selectNotice({ targetIndex, targetId });
+
+        expect(noticeStore.selectedNotices[targetIndex]).toBeFalsy();
+      });
+    });
+
+    context('선택된 알림들에 대해', () => {
+      beforeEach(() => {
+        noticeStore.selectAllNotices();
+      });
+
+      context('해당 알림들을 읽은 상태로 변경하는 것을 서버에 요청할 경우', () => {
+        it('서버에 요청을 수행한 뒤, 서버에 알림 목록을 다시 요청', async () => {
+          await noticeStore.readSelectedNotices();
+
+          await waitFor(() => {
+            expect(spyReadSelectedNotices).toBeCalledWith({
+              selectedNoticeIds: [targetId, anotherId],
+            });
+            expect(spyFetchNotices).toBeCalled();
+          });
+        });
+      });
+
+      context('해당 알림들을 삭제된 상태로 변경하는 것을 서버에 요청할 경우', () => {
+        it('서버에 요청을 수행한 뒤, 서버에 알림 목록을 다시 요청', async () => {
+          await noticeStore.deleteSelectedNotices();
+
+          await waitFor(() => {
+            expect(spyDeleteSelectedNotices).toBeCalledWith({
+              selectedNoticeIds: [targetId, anotherId],
+            });
+            expect(spyFetchNotices).toBeCalled();
+          });
+        });
+      });
+    });
+  });
+
+  context('서버에 읽지 않은 알림 개수를 요청할 경우', () => {
+    it('응답으로 전달받은 읽지 않은 알림 개수를 상태로 저장', async () => {
+      await noticeStore.fetchUnreadNoticeCount();
+
+      expect(noticeStore.unreadNoticeCount).toBe(1);
+    });
+  });
+
+  context('특정 알림을 선택해 알림 상세 내용을 조회하면', () => {
+    beforeEach(async () => {
+      await noticeStore.fetchNotices();
+    });
+
+    it('상세 내용을 조회하고 있는 알림을 체크하는 배열의 상태를 해당 알림을 읽고 있는 것으로 갱신', () => {
+      const targetIndex = 0;
+      noticeStore.showNoticeDetail(targetIndex);
+
+      expect(noticeStore.isOpenedNotice.length).toBe(2);
+      expect(noticeStore.isOpenedNotice[0]).toBeTruthy();
+      expect(noticeStore.isOpenedNotice[1]).toBeFalsy();
+    });
+
+    context('해당 알림이 읽지 않은 상태였다면', () => {
+      it('서버에 해당 알림의 상태를 읽은 상태로 변경할 것을 요청한 뒤, '
+        + '서버에 읽지 않은 알림 개수를 다시 요청', async () => {
+        const targetId = 1;
+        await noticeStore.readNotice(targetId);
+
+        await waitFor(() => {
+          expect(spyReadNotice).toBeCalledWith(targetId);
+          expect(spyFetchUnreadNoticeCount).toBeCalled();
+        });
+      });
+    });
+
+    context('해당 알림이 읽은 상태였다면', () => {
+      it('서버에 해당 알림의 상태 변경 요쳥이나 읽지 않은 알림 개수를 갱신 요청을 수행하지 않음', async () => {
+        const targetId = 2;
+        await noticeStore.readNotice(targetId);
+
+        await waitFor(() => {
+          expect(spyReadNotice).not.toBeCalledWith(targetId);
+          expect(spyFetchUnreadNoticeCount).not.toBeCalled();
+        });
+      });
+    });
+
+    context('알림 상세 내용 조회 창을 닫으면', () => {
+      it('상세 내용을 조회하고 있는 알림을 체크하는 배열의 상태를 모두 읽고 있지 않는 것으로 갱신', () => {
         const targetIndex = 1;
-        await noticeStore.readNotice(targetIndex);
-        expect(spyReadNotice).not.toBeCalled();
+        noticeStore.showNoticeDetail(targetIndex);
+        noticeStore.closeNoticeDetail(targetIndex);
+
+        noticeStore.isOpenedNotice.forEach((showNoticeDetailStatus) => {
+          expect(showNoticeDetailStatus).toBeFalsy();
+        });
       });
     });
   });

--- a/src/stores/PlaceStore.js
+++ b/src/stores/PlaceStore.js
@@ -15,8 +15,7 @@ export default class PlaceStore extends Store {
       this.place = data;
       this.publish();
     } catch (error) {
-      const { errorMessage } = error.response.data;
-      this.placeServerError = errorMessage;
+      this.placeServerError = error.response.data;
       this.publish();
     }
   }

--- a/src/stores/PlaceStore.test.js
+++ b/src/stores/PlaceStore.test.js
@@ -1,22 +1,36 @@
 import context from 'jest-plugin-context';
 import PlaceStore from './PlaceStore';
 
-import { placeApiService } from '../services/PlaceApiService';
+let placeStore;
 
 describe('PlaceStore', () => {
-  const placeStore = new PlaceStore();
+  beforeEach(() => {
+    placeStore = new PlaceStore();
+  });
 
-  context('API 서버에 경기의 장소 데이터를 요청할 경우', () => {
-    const placeId = 1;
+  context('서버에 특정 경기의 장소 정보를 요청하는 API를 호출하면', () => {
+    context('정상적인 장소 id로 요청했을 경우', () => {
+      const placeId = 1;
 
-    it('응답으로 받아온 place를 상태로 저장', async () => {
-      placeApiService.setAccessToken('userId 1');
-      await placeStore.fetchPlace(placeId);
+      it('서버에서 응답으로 전달된 장소 정보를 상태로 저장', async () => {
+        await placeStore.fetchPlace(placeId);
 
-      const { place, placeServerError } = placeStore;
+        const { place, placeServerError } = placeStore;
+        expect(Object.keys(place).length).toBe(5);
+        expect(placeServerError).toBeFalsy();
+      });
+    });
 
-      expect(Object.keys(place).length).toBe(5);
-      expect(placeServerError).toBeFalsy();
+    context('요청한 id에 해당하는 장소가 존재하지 않는 오류가 있을 경우', () => {
+      const wrongPlaceId = 4444;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await placeStore.fetchPlace(wrongPlaceId);
+
+        const { place, placeServerError } = placeStore;
+        expect(Object.keys(place).length).toBe(0);
+        expect(placeServerError).toBe('Place Not Found');
+      });
     });
   });
 });

--- a/src/stores/PostFormStore.test.js
+++ b/src/stores/PostFormStore.test.js
@@ -3,46 +3,212 @@ import PostFormStore from './PostFormStore';
 
 import { postApiService } from '../services/PostApiService';
 
+let postFormStore;
+
 describe('PostFormStore', () => {
-  let postFormStore;
+  let spyClearFormErrors;
 
   beforeEach(() => {
     postFormStore = new PostFormStore();
+    postApiService.setAccessToken('userId 1');
+
+    spyClearFormErrors = jest.spyOn(postFormStore, 'clearFormErrors');
+  });
+
+  context('운동 이름 상태 변경 함수가 호출되면', () => {
+    const exerciseName = '운동 이름';
+
+    it('받아온 값을 운동 이름 상태에 반영 후 publish', () => {
+      postFormStore.changeGameExercise(exerciseName);
+
+      const { gameExercise } = postFormStore;
+      expect(gameExercise).toBe('운동 이름');
+      expect(postFormStore.formErrors.BLANK_GAME_EXERCISE).toBeFalsy();
+    });
   });
 
   context('날짜 상태 변경 함수가 호출되면', () => {
     const date = new Date('2022-11-26T00:00:00.000Z');
+
     it('받아온 값을 날짜 상태에 반영 후 publish', () => {
       postFormStore.changeGameDate(date);
 
       const { gameDate } = postFormStore;
       expect(gameDate).toStrictEqual(new Date('2022-11-26T00:00:00.000Z'));
+      expect(postFormStore.formErrors.BLANK_GAME_DATE).toBeFalsy();
     });
   });
 
   context('시작 시간 오전/오후 상태 변경 함수가 호출되면', () => {
     const startTimeAmPm = 'pm';
+
     it('받아온 값을 시작 시간 오전/오후 상태에 반영 후 publish', () => {
       postFormStore.changeGameStartTimeAmPm(startTimeAmPm);
 
       const { gameStartTimeAmPm } = postFormStore;
       expect(gameStartTimeAmPm).toBe('pm');
+      expect(postFormStore.formErrors.BLANK_GAME_START_AM_PM).toBeFalsy();
+    });
+  });
+
+  context('시작 시간의 시간 상태 변경 함수가 호출되면', () => {
+    context('정상적인 범위 내의 시간을 입력한 경우', () => {
+      const startHour = 8;
+
+      it('받아온 값을 시작 시간의 시간 상태에 반영 후 publish', () => {
+        postFormStore.changeGameStartHour(startHour);
+
+        const { gameStartHour } = postFormStore;
+        expect(gameStartHour).toBe(8);
+        expect(postFormStore.formErrors.BLANK_GAME_START_HOUR).toBeFalsy();
+      });
+    });
+
+    context('숫자가 아닌 값을 입력한 경우', () => {
+      const wrongStartHourWithString = '꽦꽈꼬깎꾸꺼꽊꽊';
+
+      it('시작 시간의 시간 상태를 비우고 publish', () => {
+        postFormStore.changeGameStartHour(wrongStartHourWithString);
+
+        const { gameStartHour } = postFormStore;
+        expect(gameStartHour).toBe('');
+      });
+    });
+
+    context('1보다 작은 값을 입력한 경우', () => {
+      const wrongStartHourWithLessThan1 = 0;
+
+      it('시작 시간의 시간 상태를 1로 설정하고 publish', () => {
+        postFormStore.changeGameStartHour(wrongStartHourWithLessThan1);
+
+        const { gameStartHour } = postFormStore;
+        expect(gameStartHour).toBe(1);
+      });
+    });
+
+    context('12보다 큰 값을 입력한 경우', () => {
+      const wrongStartHourWithMoreThan12 = 999;
+
+      it('시작 시간의 시간 상태를 12로 설정하고 publish', () => {
+        postFormStore.changeGameStartHour(wrongStartHourWithMoreThan12);
+
+        const { gameStartHour } = postFormStore;
+        expect(gameStartHour).toBe(12);
+      });
+    });
+  });
+
+  context('시작 시간의 분 상태 변경 함수가 호출되면', () => {
+    context('정상적인 범위 내의 분을 입력한 경우', () => {
+      const startMinute = 40;
+
+      it('받아온 값을 시작 시간의 분 상태에 반영 후 publish', () => {
+        postFormStore.changeGameStartMinute(startMinute);
+
+        const { gameStartMinute } = postFormStore;
+        expect(gameStartMinute).toBe(40);
+        expect(postFormStore.formErrors.BLANK_GAME_START_MINUTE).toBeFalsy();
+      });
+    });
+
+    context('숫자가 아닌 값이나 0보다 작은 값을 입력하려고 하는 경우', () => {
+      const wrongStartMinuteWithString = '홀롤ㄹ루롤롤롤';
+
+      it('시작 시간의 시간 상태를 비우고 publish', () => {
+        postFormStore.changeGameStartMinute(wrongStartMinuteWithString);
+
+        const { gameStartMinute } = postFormStore;
+        expect(gameStartMinute).toBe('');
+      });
+    });
+
+    context('59보다 큰 값을 입력한 경우', () => {
+      const wrongStartMinuteWithMoreThan59 = 60;
+
+      it('시작 시간의 시간 상태를 12로 설정하고 publish', () => {
+        postFormStore.changeGameStartMinute(wrongStartMinuteWithMoreThan59);
+
+        const { gameStartMinute } = postFormStore;
+        expect(gameStartMinute).toBe(59);
+      });
     });
   });
 
   context('종료 시간 오전/오후 상태 변경 함수가 호출되면', () => {
     const endTimeAmPm = 'am';
+
     it('받아온 값을 종료 시간 오전/오후 상태에 반영 후 publish', () => {
       postFormStore.changeGameEndTimeAmPm(endTimeAmPm);
 
       const { gameEndTimeAmPm } = postFormStore;
       expect(gameEndTimeAmPm).toBe('am');
+      expect(postFormStore.formErrors.BLANK_GAME_END_AM_PM).toBeFalsy();
+    });
+  });
+
+  context('종료 시간의 시간 상태 변경 함수가 호출되면', () => {
+    const endHour = 11;
+
+    it('받아온 값을 종료 시간의 시간 상태에 반영 후 publish', () => {
+      postFormStore.changeGameEndHour(endHour);
+
+      const { gameEndHour } = postFormStore;
+      expect(gameEndHour).toBe(11);
+      expect(postFormStore.formErrors.BLANK_GAME_END_HOUR).toBeFalsy();
+    });
+  });
+
+  context('종료 시간의 분 상태 변경 함수가 호출되면', () => {
+    const endMinute = 17;
+
+    it('받아온 값을 종료 시간의 분 상태에 반영 후 publish', () => {
+      postFormStore.changeGameEndMinute(endMinute);
+
+      const { gameEndMinute } = postFormStore;
+      expect(gameEndMinute).toBe(17);
+      expect(postFormStore.formErrors.BLANK_GAME_END_MINUTE).toBeFalsy();
+    });
+  });
+
+  context('운동 장소 상태 변경 함수가 호출되면', () => {
+    const gamePlaceName = '운동 장소';
+
+    it('받아온 값을 운동 장소 상태에 반영 후 publish', () => {
+      postFormStore.changePlaceName(gamePlaceName);
+
+      const { placeName } = postFormStore;
+      expect(placeName).toBe('운동 장소');
+      expect(postFormStore.formErrors.BLANK_PLACE_NAME).toBeFalsy();
+      expect(postFormStore.serverError).toBeFalsy();
+    });
+  });
+
+  context('운동 정원 상태 변경 함수가 호출되면', () => {
+    const targetMemberCount = 16;
+
+    it('받아온 값을 운동 정원 상태에 반영 후 publish', () => {
+      postFormStore.changeGameTargetMemberCount(targetMemberCount);
+
+      const { gameTargetMemberCount } = postFormStore;
+      expect(gameTargetMemberCount).toBe(16);
+      expect(postFormStore.formErrors.NULL_GAME_TARGET_MEMBER_COUNT).toBeFalsy();
+    });
+  });
+
+  context('게시글 상세 정보 상태 변경 함수가 호출되면', () => {
+    const detail = '게시글 상세 정보';
+
+    it('받아온 값을 게시글 상세 정보 상태에 반영 후 publish', () => {
+      postFormStore.changePostDetail(detail);
+
+      const { postDetail } = postFormStore;
+      expect(postDetail).toBe('게시글 상세 정보');
+      expect(postFormStore.formErrors.BLANK_POST_DETAIL).toBeFalsy();
     });
   });
 
   context('게시글 생성 API에 상태로 저장하고 있는 데이터를 전달해 호출하면', () => {
-    it('생성된 게시글 id를 반환해 반환', async () => {
-      postApiService.setAccessToken('userId 1');
+    beforeEach(() => {
       postFormStore.gameExercise = '스케이트';
       postFormStore.gameDate = new Date('2022-12-31T00:00:00.000Z');
       postFormStore.gameStartTimeAmPm = 'am';
@@ -51,17 +217,20 @@ describe('PostFormStore', () => {
       postFormStore.gameEndTimeAmPm = 'pm';
       postFormStore.gameEndHour = '04';
       postFormStore.gameEndMinute = '30';
-      postFormStore.gamePlace = '롯데월드 아이스링크';
+      postFormStore.placeName = '롯데월드 아이스링크';
       postFormStore.gameTargetMemberCount = '12';
       postFormStore.postDetail = '스케이트 입문자 모집!';
+    });
 
+    it('생성된 게시글 id를 반환해 반환', async () => {
       const postId = await postFormStore.createPost();
+      expect(spyClearFormErrors).toBeCalled();
       expect(postId).toBe(1);
     });
   });
 
   context('게시글 생성 API 호출 시 입력되지 않은 상태가 있을 경우', () => {
-    it('해당 에러 메세지의 상태와 에러 발생 여부 flag 상태를 활성화', async () => {
+    beforeEach(() => {
       postFormStore.gameExercise = '스케이트';
       postFormStore.gameDate = new Date('2022-12-31T00:00:00.000Z');
       postFormStore.gameStartTimeAmPm = 'am';
@@ -70,23 +239,77 @@ describe('PostFormStore', () => {
       postFormStore.gameEndTimeAmPm = 'pm';
       postFormStore.gameEndHour = '04';
       postFormStore.gameEndMinute = '30';
-      postFormStore.gamePlace = '';
+      postFormStore.placeName = '';
       postFormStore.gameTargetMemberCount = '12';
       postFormStore.postDetail = '';
+    });
 
+    it('해당 에러 메세지의 상태와 에러 발생 여부 flag 상태를 활성화', async () => {
       const postId = await postFormStore.createPost();
+
+      expect(spyClearFormErrors).toBeCalled();
 
       const { formErrors, hasFormErrors } = postFormStore;
 
       expect(postId).toBeFalsy();
       expect(formErrors.BLANK_GAME_DATE).toBeFalsy();
       expect(formErrors.BLANK_GAME_START_HOUR)
-        .toBe('시작 시간을 입력해주세요.');
-      expect(formErrors.BLANK_GAME_PLACE)
-        .toBe('운동 장소 이름을 입력해주세요.');
+        .toBe('날짜 및 시간을 입력하지 않았습니다.');
+      expect(formErrors.BLANK_PLACE_NAME)
+        .toBe('장소를 입력하지 않았습니다.');
       expect(formErrors.BLANK_POST_DETAIL)
-        .toBe('게시글 상세 내용을 입력해주세요.');
+        .toBe('상세 내용을 입력하지 않았습니다.');
       expect(hasFormErrors).toBeTruthy();
+    });
+  });
+
+  context('게시글 작성 페이지에 접속하거나, 입력 내용을 초기화시키거나, 게시글 작성을 중단하는 경우에는 '
+    + '입력 폼의 상태들을 초기화시키는 함수를 수행하는데, 이 경우', () => {
+    beforeEach(async () => {
+      await postFormStore.createPost();
+    });
+
+    it('입력 폼의 모든 상태들과 에러 상태들을 초기화', () => {
+      postFormStore.clearStates();
+
+      expect(postFormStore.gameExercise).toBeFalsy();
+      expect(postFormStore.gameDate).toBeTruthy();
+      expect(postFormStore.gameStartTimeAmPm).toBeFalsy();
+      expect(postFormStore.gameStartHour).toBeFalsy();
+      expect(postFormStore.gameStartMinute).toBeFalsy();
+      expect(postFormStore.gameEndTimeAmPm).toBeFalsy();
+      expect(postFormStore.gameEndHour).toBeFalsy();
+      expect(postFormStore.gameEndMinute).toBeFalsy();
+      expect(postFormStore.placeName).toBeFalsy();
+      expect(postFormStore.gameTargetMemberCount).toBeFalsy();
+      expect(postFormStore.postDetail).toBeFalsy();
+      Object.entries(postFormStore.formErrors).forEach((error) => {
+        expect(error[1]).toBeFalsy();
+      });
+    });
+
+    context('서버에서 에러가 발생해 서버 에러 상태가 저장된 상태에서도'
+      + '입력 폼의 상태들을 초기화시키는 함수가 수행되면', () => {
+      beforeEach(async () => {
+        postFormStore.gameExercise = '스케이트';
+        postFormStore.gameDate = new Date('2022-12-31T00:00:00.000Z');
+        postFormStore.gameStartTimeAmPm = 'am';
+        postFormStore.gameStartHour = '10';
+        postFormStore.gameStartMinute = '00';
+        postFormStore.gameEndTimeAmPm = 'pm';
+        postFormStore.gameEndHour = '04';
+        postFormStore.gameEndMinute = '30';
+        postFormStore.placeName = '서버 에러가 발생하는 장소 이름';
+        postFormStore.gameTargetMemberCount = '12';
+        postFormStore.postDetail = '스케이트 입문자 모집!';
+        await postFormStore.createPost();
+      });
+
+      it('입력 폼의 서버 에러 상태도 초기화', () => {
+        postFormStore.clearStates();
+
+        expect(postFormStore.serverError).toBeFalsy();
+      });
     });
   });
 });

--- a/src/stores/PostStore.js
+++ b/src/stores/PostStore.js
@@ -24,7 +24,12 @@ export default class PostStore extends Store {
 
     this.post = {};
     this.postServerError = '';
+
+    this.deletePostServerError = '';
   }
+
+  // TODO: 내가 참가하는 운동, 내가 작성한 운동 조회를 위한
+  //   적용하기 버튼 추가하기
 
   resetSearchConditionState() {
     this.exerciseSelection = false;
@@ -33,9 +38,6 @@ export default class PostStore extends Store {
     this.memberSelection = false;
     this.applicantSelection = false;
   }
-
-  // TODO: 내가 참가하는 운동, 내가 작성한 운동 조회는
-  //   선택 시 바로 filtering에 들어갈 수 있을 것 같음
 
   resetLookUpConditionState() {
     this.registeredSelection = false;
@@ -92,7 +94,19 @@ export default class PostStore extends Store {
       this.posts = data.posts;
       this.publish();
     } catch (error) {
-      this.postsServerError = error.response.data;
+      const errorMessage = error.response.data;
+
+      this.postsServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'User Not Found') {
+        this.postsServerError = '사용자를 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'Game Not Found') {
+        this.postsServerError = '경기를 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'Place Not Found') {
+        this.postsServerError = '운동 장소를 찾을 수 없습니다.';
+      }
+
       this.publish();
     }
   }
@@ -102,14 +116,41 @@ export default class PostStore extends Store {
       const data = await postApiService.fetchPost(postId);
       this.post = data;
     } catch (error) {
-      this.postServerError = error.response.data;
+      const errorMessage = error.response.data;
+
+      this.postServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'Post Not Found') {
+        this.postServerError = '게시글을 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'User Not Found') {
+        this.postServerError = '사용자를 찾을 수 없습니다.';
+      }
+
+      this.publish();
     }
   }
 
   // TODO: 게시글을 생성하는 POST 요청이 PostFormStore에서 여기로 옮겨와져야 함
 
   async deletePost(postId) {
-    await postApiService.deletePost(postId);
+    try {
+      await postApiService.deletePost(postId);
+    } catch (error) {
+      const errorMessage = error.response.data;
+
+      this.deletePostServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'Post Not Found') {
+        this.deletePostServerError = '게시글을 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'User Is Not Author') {
+        this.deletePostServerError = '접속한 사용자가 작성자가 아닙니다.';
+      }
+      if (errorMessage === 'Game Not Found') {
+        this.deletePostServerError = '경기를 찾을 수 없습니다.';
+      }
+
+      this.publish();
+    }
   }
 }
 

--- a/src/stores/PostStore.test.js
+++ b/src/stores/PostStore.test.js
@@ -3,68 +3,282 @@ import PostStore from './PostStore';
 
 import { postApiService } from '../services/PostApiService';
 
+let postStore;
+
 describe('PostStore', () => {
-  let postStore;
+  let spyResetSearchConditionState;
+  let spyResetLookUpConditionState;
 
   beforeEach(() => {
     postStore = new PostStore();
+    spyResetSearchConditionState = jest.spyOn(postStore, 'resetSearchConditionState');
+    spyResetLookUpConditionState = jest.spyOn(postStore, 'resetLookUpConditionState');
+
+    jest.clearAllMocks();
   });
 
-  context('API 서버에 게시글 리스트 데이터를 요청할 경우', () => {
-    context('정상적으로 게시글 리스트 데이터를 가져온 경우', () => {
-      it('백엔드 서버에서 응답으로 전달된 post 리스트를 상태로 저장', async () => {
-        postApiService.setAccessToken('userId 1');
+  context('게시글 목록 조회 페이지에 접속했을 때', () => {
+    context('검색 조건 설정 상태를 초기화하면', () => {
+      beforeEach(() => {
+        postStore.exerciseSelection = true;
+        postStore.placeSelection = true;
+        postStore.authorSelection = true;
+        postStore.memberSelection = true;
+        postStore.applicantSelection = true;
+      });
+
+      it('모든 검색 조건 상태를 비활성화', () => {
+        postStore.resetSearchConditionState();
+
+        expect(postStore.exerciseSelection).toBeFalsy();
+        expect(postStore.placeSelection).toBeFalsy();
+        expect(postStore.authorSelection).toBeFalsy();
+        expect(postStore.memberSelection).toBeFalsy();
+        expect(postStore.applicationSelection).toBeFalsy();
+      });
+    });
+
+    context('조회 방식 설정 상태를 초기화하면', () => {
+      beforeEach(() => {
+        postStore.registeredSelection = true;
+        postStore.writtenSelection = false;
+      });
+
+      it('모든 조회 방식 설정 상태를 비활성화', () => {
+        postStore.resetLookUpConditionState();
+
+        expect(postStore.registeredSelection).toBeFalsy();
+        expect(postStore.writtenSelection).toBeFalsy();
+      });
+    });
+  });
+
+  context('검색 조건을 변경하는 경우', () => {
+    beforeEach(() => {
+      postStore.exerciseSelection = false;
+      postStore.placeSelection = false;
+      postStore.authorSelection = false;
+      postStore.memberSelection = false;
+      postStore.applicantSelection = false;
+    });
+
+    it('각 검색 조건의 설정 상태를 반전, 조회 방식 설정 상태는 모두 비활성화', () => {
+      expect(postStore.exerciseSelection).toBeFalsy();
+      postStore.changeExerciseSelection();
+      expect(postStore.exerciseSelection).toBeTruthy();
+      expect(spyResetLookUpConditionState).toBeCalled();
+      jest.clearAllMocks();
+      postStore.changeExerciseSelection();
+      expect(postStore.exerciseSelection).toBeFalsy();
+
+      jest.clearAllMocks();
+      expect(postStore.placeSelection).toBeFalsy();
+      postStore.changePlaceSelection();
+      expect(postStore.placeSelection).toBeTruthy();
+      expect(spyResetLookUpConditionState).toBeCalled();
+
+      jest.clearAllMocks();
+      expect(postStore.authorSelection).toBeFalsy();
+      postStore.changeAuthorSelection();
+      expect(postStore.authorSelection).toBeTruthy();
+      expect(spyResetLookUpConditionState).toBeCalled();
+
+      jest.clearAllMocks();
+      expect(postStore.memberSelection).toBeFalsy();
+      postStore.changeMemberSelection();
+      expect(postStore.memberSelection).toBeTruthy();
+      expect(spyResetLookUpConditionState).toBeCalled();
+
+      jest.clearAllMocks();
+      expect(postStore.applicantSelection).toBeFalsy();
+      postStore.changeApplicantSelection();
+      expect(postStore.applicantSelection).toBeTruthy();
+      expect(spyResetLookUpConditionState).toBeCalled();
+    });
+  });
+
+  context('조회 방식을 변경하는 경우', () => {
+    beforeEach(() => {
+      postStore.registeredSelection = false;
+      postStore.writtenSelection = false;
+    });
+
+    it('선택한 조회 방식의 설정 상태를 반전시키고 다른 조회 방식 설정 상태는 비활성화, '
+      + '검색 조건 설정 상태는 모두 비활성화', () => {
+      expect(postStore.registeredSelection).toBeFalsy();
+      postStore.setRegisteredSelection();
+      expect(postStore.registeredSelection).toBeTruthy();
+      expect(spyResetSearchConditionState).toBeCalled();
+      jest.clearAllMocks();
+      postStore.setRegisteredSelection();
+      expect(postStore.registeredSelection).toBeFalsy();
+
+      jest.clearAllMocks();
+      expect(postStore.writtenSelection).toBeFalsy();
+      postStore.setWrittenSelection();
+      expect(postStore.writtenSelection).toBeTruthy();
+      expect(spyResetSearchConditionState).toBeCalled();
+    });
+  });
+
+  context('서버에 게시글 목록 데이터를 요청하는 API를 호출하면', () => {
+    beforeEach(() => {
+      postApiService.setAccessToken('userId 1');
+    });
+
+    context('정상적으로 게시글 목록 데이터를 가져온 경우', () => {
+      it('서버에서 응답으로 전달된 게시글 목록을 상태로 저장', async () => {
         await postStore.fetchPosts();
 
         const { posts, postsServerError } = postStore;
 
         expect(posts.length).toBe(2);
-        expect(Object.keys(posts[0]).length).toBe(5);
+        expect(Object.keys(posts[0]).length).toBe(6);
         expect(Object.keys(posts[1].game).length).toBe(7);
         expect(Object.keys(posts[1].place).length).toBe(1);
         expect(postsServerError).toBeFalsy();
       });
     });
 
-    context('게시물의 경기 정보를 찾을 수 없는 경우', () => {
-      // 테스트 서버에서 백엔드에서 게임을 찾지 못해서 에러가 난 상황을 가정할 수가 있는가?
-      // 약간 어거지기는 하지만 어떤 유저 아이디를 줬을 때에는
-      // 그냥 무조건 에러가 난다고 가정하고 테스트를 진행해야 할 것 같다.
+    context('접속한 사용자 정보를 찾을 수 없는 경우', () => {
+      beforeEach(() => {
+        postApiService.setAccessToken('userId 4 where UserNotFound error occurs');
+      });
 
-      it('백엔드 서버에서 응답으로 전달된 에러 메세지를 상태로 저장', async () => {
-        postApiService.setAccessToken('userId 4');
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
         await postStore.fetchPosts();
 
         const { posts, postsServerError } = postStore;
 
         expect(posts).toStrictEqual([]);
-        expect(postsServerError)
-          .toBe('주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.');
+        expect(postsServerError).toBe('사용자를 찾을 수 없습니다.');
+      });
+    });
+
+    context('특정 게시물에 연결된 경기 정보를 찾을 수 없는 경우', () => {
+      beforeEach(() => {
+        postApiService.setAccessToken('userId 10 where GameNotFound error occurs');
+      });
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await postStore.fetchPosts();
+
+        const { posts, postsServerError } = postStore;
+
+        expect(posts).toStrictEqual([]);
+        expect(postsServerError).toBe('경기를 찾을 수 없습니다.');
+      });
+    });
+
+    context('특정 경기에 연결된 운동 장소 정보를 찾을 수 없는 경우', () => {
+      beforeEach(() => {
+        postApiService.setAccessToken('userId 99 where PlaceNotFound error occurs');
+      });
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await postStore.fetchPosts();
+
+        const { posts, postsServerError } = postStore;
+
+        expect(posts).toStrictEqual([]);
+        expect(postsServerError).toBe('운동 장소를 찾을 수 없습니다.');
       });
     });
   });
 
-  context('API 서버에 게시글 상세 정보 데이터를 요청할 경우', () => {
+  context('서버에 특정 게시글의 상세 정보 데이터를 요청하는 API를 호출하면', () => {
+    beforeEach(() => {
+      postApiService.setAccessToken('userId 1');
+    });
+
     const postId = 1;
 
-    it('백엔드 서버에서 응답으로 전달된 단일 post를 상태로 저장', async () => {
-      postApiService.setAccessToken('userId 1');
-      await postStore.fetchPost(postId);
+    context('정상적으로 게시글 상세 정보를 가져온 경우', () => {
+      it('서버에서 응답으로 전달된 게시글의 상세 정보를 상태로 저장', async () => {
+        await postStore.fetchPost(postId);
 
-      const { post, postServerError } = postStore;
+        const { post, postServerError } = postStore;
 
-      expect(Object.keys(post).length).toBe(6);
-      expect(post.authorPhoneNumber).toBe('010-1111-2222');
-      expect(postServerError).toBeFalsy();
+        expect(Object.keys(post).length).toBe(6);
+        expect(Object.keys(post.authorInformation).length).toBe(6);
+        expect(postServerError).toBeFalsy();
+      });
+    });
+
+    context('게시글 정보를 찾을 수 없는 경우', () => {
+      const wrongPostId = 9999;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await postStore.fetchPost(wrongPostId);
+
+        const { post, postServerError } = postStore;
+
+        expect(Object.keys(post).length).toBe(0);
+        expect(postServerError).toBe('게시글을 찾을 수 없습니다.');
+      });
+    });
+
+    context('접속한 사용자 정보를 찾을 수 없거나, 게시글의 작성자 정보를 찾을 수 없는 경우', () => {
+      beforeEach(() => {
+        postApiService.setAccessToken('userId 22 where UserNotFound error occurs');
+      });
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await postStore.fetchPost(postId);
+
+        const { post, postServerError } = postStore;
+
+        expect(Object.keys(post).length).toBe(0);
+        expect(postServerError).toBe('사용자를 찾을 수 없습니다.');
+      });
     });
   });
 
-  context('API 서버에 특정 게시글의 삭제를 요청할 경우', () => {
+  context('서버에 특정 게시글의 삭제를 요청하는 API를 호출하면', () => {
+    beforeEach(() => {
+      postApiService.setAccessToken('userId 1');
+    });
+
     const postId = 1;
 
-    it('백엔드 서버의 204 응답을 확인', async () => {
-      postApiService.setAccessToken('userId 1');
-      await postStore.deletePost(postId);
+    context('정상적인 요청이 이루어졌을 경우', () => {
+      it('삭제 요청을 수행', async () => {
+        await postStore.deletePost(postId);
+
+        expect(postStore.deletePostServerError).toBeFalsy();
+      });
+    });
+
+    context('게시글 정보를 찾을 수 없는 경우', () => {
+      const wrongPostId = 9999;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await postStore.deletePost(wrongPostId);
+
+        expect(postStore.deletePostServerError).toBe('게시글을 찾을 수 없습니다.');
+      });
+    });
+
+    context('접속한 사용자가 작성자가 아닌 경우', () => {
+      beforeEach(() => {
+        postApiService.setAccessToken('another userId 122');
+      });
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await postStore.deletePost(postId);
+
+        expect(postStore.deletePostServerError).toBe('접속한 사용자가 작성자가 아닙니다.');
+      });
+    });
+
+    context('게시글에 연결된 게임 정보를 찾을 수 없는 경우', () => {
+      const postIdWhereGameNotFound = 7876;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await postStore.deletePost(postIdWhereGameNotFound);
+
+        expect(postStore.deletePostServerError).toBe('경기를 찾을 수 없습니다.');
+      });
     });
   });
 });

--- a/src/stores/RegisterStore.js
+++ b/src/stores/RegisterStore.js
@@ -16,7 +16,7 @@ export default class RegisterStore extends Store {
     this.applicants = [];
     this.applicantsServerError = '';
 
-    this.registerAcceptServerError = '';
+    this.changeRegisterServerError = '';
   }
 
   async fetchMembers(gameId) {
@@ -46,30 +46,103 @@ export default class RegisterStore extends Store {
       this.registeredGameId = await registerApiService.registerGame(gameId);
       return this.registeredGameId;
     } catch (error) {
-      this.registerServerError = error.response.data;
+      const errorMessage = error.response.data;
+
+      this.registerServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'User Not Found') {
+        this.registerServerError = '사용자를 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'Game Not Found') {
+        this.registerServerError = '등록된 경기를 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'Already Joined Game') {
+        this.registerServerError = '이미 참가 신청 중이거나, 참가 신청이 완료된 경기입니다.';
+      }
+      if (errorMessage === 'Game Is Full') {
+        this.registerServerError = '정원이 모두 차 참가를 신청할 수 없습니다.';
+      }
+      if (errorMessage === 'Post Not Found') {
+        this.registerServerError = '경기가 등록된 게시물을 찾을 수 없습니다.';
+      }
+
       this.publish();
       return '';
     }
   }
 
   async cancelRegisterGame(registerId) {
-    await registerApiService.cancelRegisterGame(registerId);
+    try {
+      await registerApiService.cancelRegisterGame(registerId);
+    } catch (error) {
+      const errorMessage = error.response.data;
+
+      this.changeRegisterServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'Register Not Found') {
+        this.changeRegisterServerError = '등록된 신청 상태를 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'Is Not Register Of Current User') {
+        this.changeRegisterServerError = '신청 상태가 접속한 사용자의 신청 상태가 아닙니다.';
+      }
+
+      this.publish();
+    }
   }
 
   async cancelParticipateGame(registerId) {
-    await registerApiService.cancelParticipateGame(registerId);
+    try {
+      await registerApiService.cancelParticipateGame(registerId);
+    } catch (error) {
+      const errorMessage = error.response.data;
+
+      this.changeRegisterServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'Register Not Found') {
+        this.changeRegisterServerError = '등록된 신청 상태를 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'Is Not Register Of Current User') {
+        this.changeRegisterServerError = '신청 상태가 접속한 사용자의 신청 상태가 아닙니다.';
+      }
+
+      this.publish();
+    }
   }
 
   async acceptRegister(registerId) {
     try {
       await registerApiService.acceptRegister(registerId);
     } catch (error) {
-      this.registerAcceptServerError = error.response.data;
+      const errorMessage = error.response.data;
+
+      this.changeRegisterServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'Register Not Found') {
+        this.changeRegisterServerError = '등록된 신청 상태를 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'Game Not Found') {
+        this.changeRegisterServerError = '등록된 경기를 찾을 수 없습니다.';
+      }
+      if (errorMessage === 'Game Is Full') {
+        this.changeRegisterServerError = '정원이 모두 차 참가를 신청할 수 없습니다.';
+      }
+      if (errorMessage === 'User Not Found') {
+        this.changeRegisterServerError = '사용자를 찾을 수 없습니다.';
+      }
+
+      this.publish();
     }
   }
 
   async rejectRegister(registerId) {
-    await registerApiService.rejectRegister(registerId);
+    try {
+      await registerApiService.rejectRegister(registerId);
+    } catch (error) {
+      const errorMessage = error.response.data;
+
+      this.changeRegisterServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'Register Not Found') {
+        this.changeRegisterServerError = '등록된 신청 상태를 찾을 수 없습니다.';
+      }
+
+      this.publish();
+    }
   }
 }
 

--- a/src/stores/RegisterStore.test.js
+++ b/src/stores/RegisterStore.test.js
@@ -8,169 +8,269 @@ describe('RegisterStore', () => {
 
   beforeEach(() => {
     registerStore = new RegisterStore();
+    registerApiService.setAccessToken('userId 1');
   });
 
-  context('API 서버에 게시글 게임의 참가자 상세 정보 데이터를 요청할 경우', () => {
+  context('서버에 게시글 게임의 참가자 목록 데이터를 요청하는 API를 호출하면', () => {
+    context('정상적으로 게임의 참가자 목록이 찾아졌을 경우', () => {
+      const gameId = 1;
+
+      it('서버에서 응답으로 전달된 참가자 목록을 상태로 저장', async () => {
+        await registerStore.fetchMembers(gameId);
+
+        const { members, membersServerError } = registerStore;
+
+        expect(members.length).toBe(2);
+        expect(members[0].userInformation.name).toBe('작성자');
+        expect(members[1].userInformation.gender).toBe('여성');
+        expect(membersServerError).toBeFalsy();
+      });
+    });
+
+    context('참가 상태에 매칭되는 사용자가 찾아지지 않는 오류가 발생했을 경우', () => {
+      const gameIdWithProblems = 444;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.fetchMembers(gameIdWithProblems);
+
+        const { members, membersServerError } = registerStore;
+
+        expect(members.length).toBe(0);
+        expect(membersServerError).toBe('User Not Found');
+      });
+    });
+  });
+
+  context('서버에 게시글 게임의 신청자 목록 데이터를 요청하는 API를 호출하면', () => {
+    context('정상적으로 게임의 신청자 목록이 찾아졌을 경우', () => {
+      const gameId = 2;
+
+      it('서버에서 응답으로 전달된 신청자 목록을 상태로 저장', async () => {
+        await registerStore.fetchApplicants(gameId);
+
+        const { applicants, applicantsServerError } = registerStore;
+
+        expect(applicants.length).toBe(2);
+        expect(applicants[0].userInformation.name).toBe('신청자 1');
+        expect(applicants[1].userInformation.gender).toBe('남성');
+        expect(applicantsServerError).toBeFalsy();
+      });
+    });
+
+    context('참가 신청 상태에 맞는 사용자가 찾아지지 않는 오류가 발생했을 경우', () => {
+      const gameIdWithProblems = 666;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.fetchApplicants(gameIdWithProblems);
+
+        const { applicants, applicantsServerError } = registerStore;
+
+        expect(applicants.length).toBe(0);
+        expect(applicantsServerError).toBe('User Not Found');
+      });
+    });
+  });
+
+  context('운동 참가 신청 상태를 생성하는 요청 API를 호출할 경우', () => {
     const gameId = 1;
 
-    it('백엔드 서버에서 응답으로 전달된 member 컬렉션을 상태로 저장', async () => {
-      registerApiService.setAccessToken('userId 1');
-      await registerStore.fetchMembers(gameId);
+    context('서버에서 정상적으로 신청 상태를 생성했을 경우', () => {
+      it('서버로부터 응답으로 전달받은 신청 상태가 속하는 gameId를 호출한 대상에 반환', async () => {
+        const registeredGameId = await registerStore.registerGame(gameId);
 
-      const { members, membersErrorMessage } = registerStore;
-
-      expect(members.length).toBe(2);
-      expect(members[0].name).toBe('작성자');
-      expect(members[1].gender).toBe('여성');
-      expect(membersErrorMessage).toBeFalsy();
+        expect(registeredGameId).toBe(1);
+        expect(registerStore.registerServerError).toBe('');
+      });
     });
-  });
 
-  context('API 서버에 게시글 게임의 신청자 상세 정보 데이터를 요청할 경우', () => {
-    const gameId = 2;
+    context('잘못된 Access Token으로 요청했거나, 알림 생성을 위한 게시글 작성자 정보를 찾을 수 없는 경우', () => {
+      beforeEach(() => {
+        registerApiService.setAccessToken('wrong userId 4444');
+      });
 
-    it('백엔드 서버에서 응답으로 전달된 applicant 컬렉션을 상태로 저장', async () => {
-      registerApiService.setAccessToken('userId 1');
-      await registerStore.fetchApplicants(gameId);
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장하고, '
+        + 'gameId가 아닌 빈 값을 호출한 대상에 반환', async () => {
+        const registeredGameId = await registerStore.registerGame(gameId);
 
-      const { applicants, applicantsErrorMessage } = registerStore;
-
-      expect(applicants.length).toBe(2);
-      expect(applicants[0].name).toBe('신청자 1');
-      expect(applicants[1].gender).toBe('남성');
-      expect(applicantsErrorMessage).toBeFalsy();
+        expect(registeredGameId).toBeFalsy();
+        expect(registerStore.registerServerError)
+          .toBe('사용자를 찾을 수 없습니다.');
+      });
     });
-  });
 
-  context('운동 참가 신청 API를 요청할 경우 (정상 케이스)', () => {
-    it('registerApiService 신청자 생성 POST API 요청을 호출하고 응답으로 받은 gameId를 반환', async () => {
-      // cf. localStorage.setItem()으로 token을 설정해줄 수도 있다.
-      registerApiService.setAccessToken('userId 1');
-      const gameId = 1;
-      await registerStore.registerToGame(gameId);
+    context('존재하지 않는 game Id로 요청했을 경우', () => {
+      const wrongGameId = 6646;
 
-      const { registeredGameId, registerErrorCodeAndMessage } = registerStore;
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장하고, '
+      + 'gameId가 아닌 빈 값을 호출한 대상에 반환', async () => {
+        const registeredGameId = await registerStore.registerGame(wrongGameId);
 
-      expect(registeredGameId).toBe(1);
-      expect(registerErrorCodeAndMessage).toStrictEqual({});
+        expect(registeredGameId).toBeFalsy();
+        expect(registerStore.registerServerError)
+          .toBe('등록된 경기를 찾을 수 없습니다.');
+      });
     });
-  });
 
-  context('존재하지 않는 game Id로 운동 참가 신청 API를 요청할 경우', () => {
-    it('게임을 찾을 수 없다는 에러 상태 저장', async () => {
-      registerApiService.setAccessToken('userId 1');
-      const wrongGameId = 100;
-      await registerStore.registerToGame(wrongGameId);
+    context('이미 참가 신청 중이었던 게임이었을 경우', () => {
+      const alreadyJoinedGameId = 123;
 
-      const { registeredGameId, registerErrorCodeAndMessage } = registerStore;
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장하고, '
+      + 'gameId가 아닌 빈 값을 호출한 대상에 반환', async () => {
+        const registeredGameId = await registerStore.registerGame(alreadyJoinedGameId);
 
-      expect(registeredGameId).toBe(-1);
-      expect(registerErrorCodeAndMessage).toStrictEqual({
-        errorCode: 100,
-        errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
-        gameId: null,
+        expect(registeredGameId).toBeFalsy();
+        expect(registerStore.registerServerError)
+          .toBe('이미 참가 신청 중이거나, 참가 신청이 완료된 경기입니다.');
+      });
+    });
+
+    context('요청하는 시점에 참가 정원이 모두 차 있는 경우', () => {
+      const alreadyFullGameId = 987;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장하고, '
+      + 'gameId가 아닌 빈 값을 호출한 대상에 반환', async () => {
+        const registeredGameId = await registerStore.registerGame(alreadyFullGameId);
+
+        expect(registeredGameId).toBeFalsy();
+        expect(registerStore.registerServerError)
+          .toBe('정원이 모두 차 참가를 신청할 수 없습니다.');
+      });
+    });
+
+    context('참가 신청을 완료했더라도 알림 생성을 위해 게임이 등록된 게시글을 찾을 수 없는 경우에는', () => {
+      const postNotFoundGameId = 7272;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장하고, '
+      + 'gameId가 아닌 빈 값을 호출한 대상에 반환', async () => {
+        const registeredGameId = await registerStore.registerGame(postNotFoundGameId);
+
+        expect(registeredGameId).toBeFalsy();
+        expect(registerStore.registerServerError)
+          .toBe('경기가 등록된 게시물을 찾을 수 없습니다.');
       });
     });
   });
 
-  context('신청이 완료된 user Id로 운동 참가 신청 API를 요청할 경우', () => {
-    it('신청이 완료된 운동이라는 에러 상태 저장', async () => {
-      registerApiService.setAccessToken('already registered userId 2');
-      const gameId = 1;
-      await registerStore.registerToGame(gameId);
+  context('운동 참가 신청 취소, 또는 운동 참가 취소를 요청하는 API를 호출할 경우', () => {
+    const registerId = 1;
 
-      const { registeredGameId, registerErrorCodeAndMessage } = registerStore;
+    context('해당 신청 상태가 존재할 경우', () => {
+      it('접속한 사용자의 신청 상태를 취소 상태로 변경하는 요청 호출', async () => {
+        await registerStore.cancelRegisterGame(registerId);
+        expect(registerStore.changeRegisterServerError).toBeFalsy();
 
-      expect(registeredGameId).toBe(-1);
-      expect(registerErrorCodeAndMessage).toStrictEqual({
-        errorCode: 101,
-        errorMessage: '이미 신청 중이거나 신청이 완료된 운동입니다.',
-        gameId: null,
+        await registerStore.cancelParticipateGame(registerId);
+        expect(registerStore.changeRegisterServerError).toBeFalsy();
+      });
+    });
+
+    context('신청 상태가 존재하지 않는 오류가 있을 경우', () => {
+      const notExistingRegisterId = 4455;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.cancelRegisterGame(notExistingRegisterId);
+        expect(registerStore.changeRegisterServerError)
+          .toBe('등록된 신청 상태를 찾을 수 없습니다.');
+
+        await registerStore.cancelParticipateGame(notExistingRegisterId);
+        expect(registerStore.changeRegisterServerError)
+          .toBe('등록된 신청 상태를 찾을 수 없습니다.');
+      });
+    });
+
+    context('신청 상태가 접속한 사용자에 해당하는 신청 상태가 아닌 오류가 있을 경우', () => {
+      beforeEach(() => {
+        registerApiService.setAccessToken('userId 4444');
+      });
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.cancelRegisterGame(registerId);
+        expect(registerStore.changeRegisterServerError)
+          .toBe('신청 상태가 접속한 사용자의 신청 상태가 아닙니다.');
+
+        await registerStore.cancelParticipateGame(registerId);
+        expect(registerStore.changeRegisterServerError)
+          .toBe('신청 상태가 접속한 사용자의 신청 상태가 아닙니다.');
       });
     });
   });
 
-  context('존재하지 않는 user Id로 운동 참가 신청 API를 요청할 경우', () => {
-    it('사용자를 찾을 수 없다는 에러 상태 저장', async () => {
-      registerApiService.setAccessToken('not existed userId 3');
-      const targetGameId = 1;
-      await registerStore.registerToGame(targetGameId);
+  context('운동 참가 신청 수락을 요청하는 API를 호출할 경우', () => {
+    const registerId = 1;
 
-      const {
-        registeredGameId,
-        registerErrorCodeAndMessage,
-      } = registerStore;
-
-      expect(registeredGameId).toBe(-1);
-      expect(registerErrorCodeAndMessage).toStrictEqual({
-        errorCode: 102,
-        errorMessage: '주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다.',
-        gameId: null,
-      });
-    });
-
-    context('user Id로 운동 참가 신청 API를 요청했지만 정원이 마감된 경우', () => {
-      it('참가 정원이 모두 차 참가를 신청할 수 없다는 에러 상태 저장', async () => {
-        registerApiService.setAccessToken('fully participated userId 3');
-        const targetGameId = 1;
-        await registerStore.registerToGame(targetGameId);
-
-        const {
-          registeredGameId,
-          registerErrorCodeAndMessage,
-        } = registerStore;
-
-        expect(registeredGameId).toBe(-1);
-        expect(registerErrorCodeAndMessage).toStrictEqual({
-          errorCode: 103,
-          errorMessage: '참가 정원이 모두 차 참가를 신청할 수 없습니다.',
-          gameId: 1,
-        });
-      });
-    });
-  });
-
-  context('운동 참가 신청 취소 API를 요청할 경우', () => {
-    it('RegisterApiService 신청자 상태를 취소로 변경하는 PATCH API 요청 호출', async () => {
-      registerApiService.setAccessToken('userId 1');
-      const registerId = 1;
-      await registerStore.cancelRegisterToGame(registerId);
-    });
-  });
-
-  context('운동 참가 취소 API를 요청할 경우', () => {
-    it('RegisterApiService 신청자 상태를 취소로 변경하는 PATCH API 요청 호출', async () => {
-      registerApiService.setAccessToken('userId 1');
-      const registerId = 1;
-      await registerStore.cancelParticipateToGame(registerId);
-    });
-  });
-
-  context('운동 참가 수락 API를 요청할 경우', () => {
-    it('RegisterApiService 신청자 상태를 참가로 변경하는 PATCH API 요청 호출', async () => {
-      registerApiService.setAccessToken('userId 1');
-      const registerId = 1;
-      await registerStore.acceptRegister(registerId);
-    });
-
-    context('운동 참가 수락 API에서 에러가 반환될 경우', () => {
-      it('에러 메세지를 상태로 저장', async () => {
-        registerApiService.setAccessToken('userId 1');
-        const registerId = 2;
+    context('해당 신청 상태가 존재할 경우', () => {
+      it('신청자의 신청 상태를 참가 상태로 변경하는 요청 호출', async () => {
         await registerStore.acceptRegister(registerId);
 
-        const { registerErrorCodeAndMessage } = registerStore;
-        expect(registerErrorCodeAndMessage)
-          .toBe('정원이 가득 차 있어 운동 참가 신청을 수락할 수 없습니다.');
+        expect(registerStore.changeRegisterServerError).toBeFalsy();
+      });
+    });
+
+    context('신청 상태가 존재하지 않는 오류가 있을 경우', () => {
+      const notExistingRegisterId = 4455;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.acceptRegister(notExistingRegisterId);
+
+        expect(registerStore.changeRegisterServerError)
+          .toBe('등록된 신청 상태를 찾을 수 없습니다.');
+      });
+    });
+
+    context('신청 상태가 속한 게임이 존재하지 않는 오류가 있을 경우', () => {
+      const registerIdWithoutGame = 273;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.acceptRegister(registerIdWithoutGame);
+
+        expect(registerStore.changeRegisterServerError)
+          .toBe('등록된 경기를 찾을 수 없습니다.');
+      });
+    });
+
+    context('호출하는 시점에 신청 상태가 속한 게임 정원이 가득 차있는 경우', () => {
+      const registerIdWithAlreadyFullGame = 555;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.acceptRegister(registerIdWithAlreadyFullGame);
+
+        expect(registerStore.changeRegisterServerError)
+          .toBe('정원이 모두 차 참가를 신청할 수 없습니다.');
+      });
+    });
+
+    context('참가 신청 수락을 완료했더라도 알림 생성을 위해 신청 상태에 해당하는 사용자를 찾을 수 없는 경우에는', () => {
+      const registerIdWithoutUser = 2580;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.acceptRegister(registerIdWithoutUser);
+
+        expect(registerStore.changeRegisterServerError)
+          .toBe('사용자를 찾을 수 없습니다.');
       });
     });
   });
 
-  context('운동 참가 거절 API를 요청할 경우', () => {
-    it('RegisterApiService 신청자 상태를 거절로 변경하는 PATCH API 요청 호출', async () => {
-      registerApiService.setAccessToken('userId 1');
-      const registerId = 1;
-      await registerStore.rejectRegister(registerId);
+  context('운동 참가 신청 거절을 요청하는 API를 호출할 경우', () => {
+    const registerId = 1;
+
+    context('해당 신청 상태가 존재할 경우', () => {
+      it('신청자의 신청 상태를 거절 상태로 변경하는 요청 호출', async () => {
+        await registerStore.rejectRegister(registerId);
+
+        expect(registerStore.changeRegisterServerError).toBeFalsy();
+      });
+    });
+
+    context('신청 상태가 존재하지 않는 오류가 있을 경우', () => {
+      const notExistingRegisterId = 4455;
+
+      it('서버에서 응답으로 전달된 에러 메시지를 상태로 저장', async () => {
+        await registerStore.rejectRegister(notExistingRegisterId);
+
+        expect(registerStore.changeRegisterServerError)
+          .toBe('등록된 신청 상태를 찾을 수 없습니다.');
+      });
     });
   });
 });

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -30,8 +30,13 @@ export default class UserStore extends Store {
       this.name = data.name;
       this.publish();
     } catch (error) {
-      const { errorMessage } = error.response.data;
-      this.fetchUserNameServerError = errorMessage;
+      const errorMessage = error.response.data;
+
+      this.fetchUserNameServerError = '알 수 없는 에러입니다.';
+      if (errorMessage === 'User Not Found') {
+        this.fetchUserNameServerError = '사용자를 찾을 수 없습니다.';
+      }
+
       this.publish();
     }
   }

--- a/src/stores/UserStore.test.js
+++ b/src/stores/UserStore.test.js
@@ -1,4 +1,5 @@
 import context from 'jest-plugin-context';
+import { userApiService } from '../services/UserApiService';
 import UserStore from './UserStore';
 
 describe('UserStore', () => {
@@ -64,15 +65,43 @@ describe('UserStore', () => {
     });
   });
 
-  context('회원가입을 수행하는 경우', () => {
-    context('모든 정보를 정상적으로 입력하고 회원가입 함수를 호출하면', () => {
-      const name = '황인우';
-      const username = 'hsjkdss228';
-      const password = 'Password!1';
-      const confirmPassword = 'Password!1';
-      const gender = '남성';
-      const phoneNumber = '01012345678';
+  context('로그인한 사용자의 이름을 요청하는 API를 호출하는 경우', () => {
+    context('존재하는 사용자인 경우', () => {
+      beforeEach(() => {
+        userApiService.setAccessToken('userId 1');
+      });
 
+      it('응답으로 반환받은 사용자 이름을 상태로 저장', async () => {
+        await userStore.fetchUserName();
+
+        expect(userStore.name).toBe('황인우');
+        expect(userStore.fetchUserNameServerError).toBeFalsy();
+      });
+    });
+
+    context('존재하지 않는 사용자인 경우', () => {
+      beforeEach(() => {
+        userApiService.setAccessToken('not existing userId 333');
+      });
+
+      it('응답으로 반환받은 에러 메시지를 상태로 저장', async () => {
+        await userStore.fetchUserName();
+
+        expect(userStore.name).toBeFalsy();
+        expect(userStore.fetchUserNameServerError).toBe('사용자를 찾을 수 없습니다.');
+      });
+    });
+  });
+
+  context('회원가입을 수행하는 경우', () => {
+    const name = '황인우';
+    const username = 'hsjkdss228';
+    const password = 'Password!1';
+    const confirmPassword = 'Password!1';
+    const gender = '남성';
+    const phoneNumber = '01012345678';
+
+    context('모든 정보를 정상적으로 입력하고 회원가입 함수를 호출하면', () => {
       it('userApiService의 signUp을 호출해 생성되는 userId 값을 반환', async () => {
         const enrolledName = await userStore.signUp({
           name,
@@ -82,8 +111,46 @@ describe('UserStore', () => {
           gender,
           phoneNumber,
         });
+
         const expectedEnrolledName = '황인우';
         expect(enrolledName).toBe(expectedEnrolledName);
+        expect(userStore.signUpServerError).toBeFalsy();
+      });
+    });
+
+    context('이미 등록된 아이디를 입력하고 회원가입 함수를 호출하면', () => {
+      const wrongUsername = 'alreadyregisteredid12';
+
+      it('응답으로 반환받은 에러 메시지를 상태로 저장', async () => {
+        const enrolledName = await userStore.signUp({
+          name,
+          username: wrongUsername,
+          password,
+          confirmPassword,
+          gender,
+          phoneNumber,
+        });
+
+        expect(enrolledName).toBeFalsy();
+        expect(userStore.signUpServerError).toBe('이미 등록된 아이디입니다.');
+      });
+    });
+
+    context('비밀번호와 비밀번호 확인을 일치하지 않게 입력하고 회원가입 함수를 호출하면', () => {
+      const mismatchingConfirmPassword = 'wrongPassword!1';
+
+      it('응답으로 반환받은 에러 메시지를 상태로 저장', async () => {
+        const enrolledName = await userStore.signUp({
+          name,
+          username,
+          password,
+          confirmPassword: mismatchingConfirmPassword,
+          gender,
+          phoneNumber,
+        });
+
+        expect(enrolledName).toBeFalsy();
+        expect(userStore.signUpServerError).toBe('비밀번호 확인이 일치하지 않습니다.');
       });
     });
   });

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -21,6 +21,7 @@ const testServer = setupServer(
             {
               id: 1,
               hits: 334,
+              thumbnailImageUrl: 'image url 1',
               isAuthor: false,
               game: {
                 id: 1,
@@ -38,6 +39,7 @@ const testServer = setupServer(
             {
               id: 2,
               hits: 10,
+              thumbnailImageUrl: 'image url 2',
               isAuthor: false,
               game: {
                 id: 1,
@@ -49,19 +51,31 @@ const testServer = setupServer(
                 registerStatus: 'accepted',
               },
               place: {
-                name: '대전월드컵경기장',
+                name: '농구장',
               },
             },
           ],
         }));
       }
 
-      if (accessToken === 'userId 4') {
+      if (accessToken === 'userId 4 where UserNotFound error occurs') {
         return response(
           context.status(400),
-          context.json({
-            errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
-          }),
+          context.json('User Not Found'),
+        );
+      }
+
+      if (accessToken === 'userId 10 where GameNotFound error occurs') {
+        return response(
+          context.status(400),
+          context.json('Game Not Found'),
+        );
+      }
+
+      if (accessToken === 'userId 99 where PlaceNotFound error occurs') {
+        return response(
+          context.status(400),
+          context.json('Place Not Found'),
         );
       }
 
@@ -69,80 +83,57 @@ const testServer = setupServer(
     },
   ),
 
-  // registerToGame
-  rest.post(
-    `${apiBaseUrl}/registers/games/:gameId`,
+  // fetchPost
+  rest.get(
+    `${apiBaseUrl}/posts/:postId`,
     async (request, response, context) => {
       const accessToken = await request.headers.get('Authorization')
         .substring('bearer '.length);
-      const { gameId } = await request.params;
+      const { postId } = await request.params;
 
-      if (gameId === '1' && accessToken === 'userId 1') {
-        return response(context.json({
-          gameId: 1,
-        }));
-      }
-
-      if (gameId === '100' && accessToken === 'userId 1') {
+      const normalPostId = '1';
+      if (postId === normalPostId && accessToken === 'userId 1') {
         return response(
-          context.status(400),
+          context.status(200),
           context.json({
-            errorCode: 100,
-            errorMessage: '주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.',
-            gameId: null,
+            id: 1,
+            hits: 223,
+            authorInformation: {
+              id: 1,
+              name: '작성자',
+              gender: '남성',
+              phoneNumber: '010-1111-2222',
+              profileImageUrl: 'image url 1',
+              mannerScore: 9.5,
+            },
+            detail: '탁구 비는 인원 모집',
+            imageUrls: [
+              'image url 1',
+              'image url 2',
+            ],
+            isAuthor: true,
           }),
         );
       }
 
-      if (gameId === '1' && accessToken === 'already registered userId 2') {
+      const wrongPostId = '9999';
+      if (postId === wrongPostId) {
         return response(
-          context.status(400),
-          context.json({
-            errorCode: 101,
-            errorMessage: '이미 신청 중이거나 신청이 완료된 운동입니다.',
-            gameId: null,
-          }),
+          context.status(404),
+          context.json('Post Not Found'),
         );
       }
 
-      if (gameId === '1' && accessToken === 'not existed userId 3') {
+      if (accessToken === 'userId 22 where UserNotFound error occurs') {
         return response(
-          context.status(400),
-          context.json({
-            errorCode: 102,
-            errorMessage: '주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다.',
-            gameId: null,
-          }),
+          context.status(404),
+          context.json('User Not Found'),
         );
       }
 
-      if (gameId === '1' && accessToken === 'fully participated userId 3') {
-        return response(
-          context.status(400),
-          context.json({
-            errorCode: 103,
-            errorMessage: '참가 정원이 모두 차 참가를 신청할 수 없습니다.',
-            gameId: 1,
-          }),
-        );
-      }
-
-      return response(context.status(400));
-    },
-  ),
-
-  // cancelParticipateGame
-  rest.patch(
-    `${apiBaseUrl}/registers/games/:gameId`,
-    async (request, response, context) => {
-      const accessToken = await request.headers.get('Authorization');
-      const { gameId } = await request.params;
-
-      if (gameId === '1' && accessToken) {
-        return response(context.status(204));
-      }
-
-      return response(context.status(400));
+      return response(
+        context.status(400),
+      );
     },
   ),
 
@@ -206,34 +197,6 @@ const testServer = setupServer(
     },
   ),
 
-  // fetchPost
-  rest.get(
-    `${apiBaseUrl}/posts/:postId`,
-    async (request, response, context) => {
-      const accessToken = await request.headers.get('Authorization')
-        .substring('bearer '.length);
-      const { postId } = await request.params;
-
-      if (postId === '1' && accessToken === 'userId 1') {
-        return response(
-          context.status(200),
-          context.json({
-            id: 1,
-            hits: 223,
-            authorName: '작성자',
-            authorPhoneNumber: '010-1111-2222',
-            detail: '점심먹고 가볍게 탁구하실분?',
-            isAuthor: true,
-          }),
-        );
-      }
-
-      return response(
-        context.status(400),
-      );
-    },
-  ),
-
   // fetchGame
   rest.get(
     `${apiBaseUrl}/games/posts/:postId`,
@@ -249,12 +212,26 @@ const testServer = setupServer(
             id: 1,
             placeId: 1,
             type: '탁구',
-            date: '2022년 10월 19일 12:30~13:30',
+            date: '2022년 10월 19일 12:30 ~ 13:30',
             currentMemberCount: 2,
             targetMemberCount: 4,
             registerId: -1,
             registerStatus: 'none',
           }),
+        );
+      }
+
+      if (accessToken === 'Wrong Access Token') {
+        return response(
+          context.status(404),
+          context.json('User Not Found'),
+        );
+      }
+
+      if (postId === '444') {
+        return response(
+          context.status(404),
+          context.json('Game Not Found'),
         );
       }
 
@@ -268,11 +245,9 @@ const testServer = setupServer(
   rest.get(
     `${apiBaseUrl}/places/:placeId`,
     async (request, response, context) => {
-      const accessToken = await request.headers.get('Authorization')
-        .substring('bearer '.length);
       const { placeId } = await request.params;
 
-      if (placeId === '1' && accessToken === 'userId 1') {
+      if (placeId === '1') {
         return response(
           context.status(200),
           context.json({
@@ -282,6 +257,13 @@ const testServer = setupServer(
             address: '주소지',
             contactNumber: '02-0000-0000',
           }),
+        );
+      }
+
+      if (placeId === '4444') {
+        return response(
+          context.status(404),
+          context.json('Place Not Found'),
         );
       }
 
@@ -303,19 +285,36 @@ const testServer = setupServer(
           context.json({
             members: [
               {
-                id: 1,
-                name: '작성자',
-                gender: '남성',
-                phoneNumber: '010-1111-2222',
+                registerId: 1,
+                userInformation: {
+                  id: 1,
+                  name: '작성자',
+                  gender: '남성',
+                  phoneNumber: '010-1111-2222',
+                  profileImageUrl: 'Image Url 1',
+                  mannerScore: 10.0,
+                },
               },
               {
-                id: 2,
-                name: '사용자 2',
-                gender: '여성',
-                phoneNumber: '010-9999-9999',
+                registerId: 2,
+                userInformation: {
+                  id: 2,
+                  name: '사용자 2',
+                  gender: '여성',
+                  phoneNumber: '010-9999-9999',
+                  profileImageUrl: 'Image Url 2',
+                  mannerScore: 0.1,
+                },
               },
             ],
           }),
+        );
+      }
+
+      if (gameId === '444') {
+        return response(
+          context.status(404),
+          context.json('User Not Found'),
         );
       }
 
@@ -337,19 +336,36 @@ const testServer = setupServer(
           context.json({
             applicants: [
               {
-                id: 1,
-                name: '신청자 1',
-                gender: '여성',
-                phoneNumber: '010-1357-1357',
+                registerId: 3,
+                userInformation: {
+                  id: 3,
+                  name: '신청자 1',
+                  gender: '여성',
+                  phoneNumber: '010-1357-1357',
+                  profileImageUrl: 'Image Url 3',
+                  mannerScore: 5.0,
+                },
               },
               {
-                id: 2,
-                name: '신청자 2',
-                gender: '남성',
-                phoneNumber: '010-2468-2468',
+                registerId: 4,
+                userInformation: {
+                  id: 4,
+                  name: '신청자 2',
+                  gender: '남성',
+                  phoneNumber: '010-2468-2468',
+                  profileImageUrl: 'Image Url 4',
+                  mannerScore: 6.9,
+                },
               },
             ],
           }),
+        );
+      }
+
+      if (gameId === '666') {
+        return response(
+          context.status(404),
+          context.json('User Not Found'),
         );
       }
 
@@ -359,27 +375,151 @@ const testServer = setupServer(
     },
   ),
 
+  // registerGame
+  rest.post(
+    `${apiBaseUrl}/registers/games/:gameId`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
+      const { gameId } = await request.params;
+
+      const normalGameId = '1';
+      if (gameId === normalGameId && accessToken === 'userId 1') {
+        return response(
+          context.status(201),
+          context.json({
+            gameId: 1,
+          }),
+        );
+      }
+
+      if (accessToken === 'wrong userId 4444') {
+        return response(
+          context.status(404),
+          context.json('User Not Found'),
+        );
+      }
+
+      const notExistingGameId = '6646';
+      if (gameId === notExistingGameId) {
+        return response(
+          context.status(404),
+          context.json('Game Not Found'),
+        );
+      }
+
+      const alreadyJoinedGameId = '123';
+      if (gameId === alreadyJoinedGameId) {
+        return response(
+          context.status(400),
+          context.json('Already Joined Game'),
+        );
+      }
+
+      const alreadyFullGameId = '987';
+      if (gameId === alreadyFullGameId) {
+        return response(
+          context.status(400),
+          context.json('Game Is Full'),
+        );
+      }
+
+      const gameIdWithoutPost = '7272';
+      if (gameId === gameIdWithoutPost) {
+        return response(
+          context.status(404),
+          context.json('Post Not Found'),
+        );
+      }
+
+      return response(context.status(400));
+    },
+  ),
+
+  // cancelParticipateGame
+  rest.patch(
+    `${apiBaseUrl}/registers/games/:gameId`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization');
+      const { gameId } = await request.params;
+
+      if (gameId === '1' && accessToken) {
+        return response(context.status(204));
+      }
+
+      return response(context.status(400));
+    },
+  ),
+
   // change register state methods
   rest.patch(
     `${apiBaseUrl}/registers/:registerId`,
     async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
       const { registerId } = await request.params;
       const status = await request.url.searchParams.get('status');
 
-      if (registerId === '2') {
+      const normalRegisterId = '1';
+
+      if (accessToken === 'userId 1'
+        && registerId === normalRegisterId
+        && (status === 'canceled'
+        || status === 'accepted'
+        || status === 'rejected')) {
         return response(
-          context.status(400),
-          context.json(
-            '정원이 가득 차 있어 운동 참가 신청을 수락할 수 없습니다.',
-          ),
+          context.status(204),
         );
       }
 
-      if (status === 'canceled'
-        || status === 'accepted'
-        || status === 'rejected') {
+      const notExistingRegisterId = '4455';
+      if (accessToken === 'userId 1'
+        && (status === 'canceled'
+          || status === 'accepted'
+          || status === 'rejected')
+        && registerId === notExistingRegisterId) {
         return response(
-          context.status(204),
+          context.status(404),
+          context.json('Register Not Found'),
+        );
+      }
+
+      if (accessToken === 'userId 4444'
+        && status === 'canceled'
+        && registerId === normalRegisterId) {
+        return response(
+          context.status(400),
+          context.json('Is Not Register Of Current User'),
+        );
+      }
+
+      const registerIdWithoutGame = '273';
+      if (accessToken === 'userId 1'
+        && status === 'accepted'
+        && registerId === registerIdWithoutGame) {
+        return response(
+          context.status(404),
+          context.json('Game Not Found'),
+        );
+      }
+
+      const registerIdWithAlreadyFullGame = '555';
+      if (accessToken === 'userId 1'
+        && status === 'accepted'
+        && registerId === registerIdWithAlreadyFullGame) {
+        return response(
+          context.status(400),
+          context.json('Game Is Full'),
+        );
+      }
+
+      const registerIdWithoutUser = '2580';
+      if (accessToken === 'userId 1'
+        && status === 'accepted'
+        && registerId === registerIdWithoutUser) {
+        return response(
+          context.status(404),
+          context.json('User Not Found'),
         );
       }
 
@@ -394,38 +534,38 @@ const testServer = setupServer(
     `${apiBaseUrl}/posts`,
     async (request, response, context) => {
       const {
-        gameExercise,
-        gameDate,
-        gameStartTimeAmPm,
-        gameStartHour,
-        gameStartMinute,
-        gameEndTimeAmPm,
-        gameEndHour,
-        gameEndMinute,
-        gamePlace,
-        gameTargetMemberCount,
-        postDetail,
+        post,
+        game,
+        exercise,
+        place,
       } = await request.json();
       const accessToken = await request.headers.get('Authorization')
         .substring('bearer '.length);
 
-      if (gameExercise === '스케이트'
-        && gameDate === new Date('2022-12-31T00:00:00.000Z').toISOString()
-        && gameStartTimeAmPm === 'am'
-        && gameStartHour === '10'
-        && gameStartMinute === '00'
-        && gameEndTimeAmPm === 'pm'
-        && gameEndHour === '04'
-        && gameEndMinute === '30'
-        && gamePlace === '롯데월드 아이스링크'
-        && gameTargetMemberCount === '12'
-        && postDetail === '스케이트 입문자 모집!'
+      if (exercise.name === '스케이트'
+        && game.date === new Date('2022-12-31T00:00:00.000Z').toISOString()
+        && game.startTimeAmPm === 'am'
+        && game.startHour === '10'
+        && game.startMinute === '00'
+        && game.endTimeAmPm === 'pm'
+        && game.endHour === '04'
+        && game.endMinute === '30'
+        && place.name === '롯데월드 아이스링크'
+        && game.targetMemberCount === '12'
+        && post.detail === '스케이트 입문자 모집!'
         && accessToken === 'userId 1') {
         return response(
           context.status(201),
           context.json({
             postId: 1,
           }),
+        );
+      }
+
+      if (place.name === '서버 에러가 발생하는 장소 이름') {
+        return response(
+          context.status(400),
+          context.json('Place Not Found'),
         );
       }
 
@@ -443,9 +583,33 @@ const testServer = setupServer(
       const accessToken = await request.headers.get('Authorization')
         .substring('bearer '.length);
 
-      if (postId === '1' && accessToken === 'userId 1') {
+      const normalPostId = '1';
+      if (postId === normalPostId && accessToken === 'userId 1') {
         return response(
           context.status(204),
+        );
+      }
+
+      const wrongPostId = '9999';
+      if (postId === wrongPostId) {
+        return response(
+          context.status(404),
+          context.json('Post Not Found'),
+        );
+      }
+
+      if (accessToken === 'another userId 122') {
+        return response(
+          context.status(400),
+          context.json('User Is Not Author'),
+        );
+      }
+
+      const postIdWhereGameNotFound = '7876';
+      if (postId === postIdWhereGameNotFound) {
+        return response(
+          context.status(404),
+          context.json('Game Not Found'),
         );
       }
 
@@ -487,6 +651,13 @@ const testServer = setupServer(
         );
       }
 
+      if (accessToken === 'Wrong Access Token') {
+        return response(
+          context.status(400),
+          context.json('Authentication Error'),
+        );
+      }
+
       return response(
         context.status(400),
       );
@@ -509,43 +680,131 @@ const testServer = setupServer(
         context.status(400),
       );
     },
+  ),
 
-    // TODO: fetchUserName 테스트 코드 추가 필요 (Store, Component)
+  // readSelectedNotices
+  // deleteSelectedNotices
+  rest.patch(
+    `${apiBaseUrl}/notices`,
+    async (request, response, context) => {
+      // const { ids } = await request.json();
+      const status = await request.url.searchParams.get('status');
 
-    // TODO: 안 짠 테스트가 많다... 많나...?
+      if (status === 'read') {
+        return response(
+          context.status(204),
+        );
+      }
 
-    // signUp
-    rest.post(
-      `${apiBaseUrl}/users`,
-      async (request, response, context) => {
-        const {
-          name,
-          username,
-          password,
-          confirmPassword,
-          gender,
-          phoneNumber,
-        } = await request.json();
+      if (status === 'deleted') {
+        return response(
+          context.status(204),
+        );
+      }
 
-        if (name === '황인우'
-        && username === 'hsjkdss228'
-        && password === 'Password!1'
-        && confirmPassword === 'Password!1'
-        && gender === '남성'
-        && phoneNumber === '01012345678') {
-          return response(
-            context.status(201),
-            context.json({
-              enrolledName: '황인우',
-            }),
-          );
-        }
+      return response(
+        context.status(400),
+      );
+    },
+  ),
 
+  // fetchUnreadNoticeCount
+  rest.get(
+    `${apiBaseUrl}/notice-count`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
+
+      if (accessToken === 'userId 1') {
+        return response(
+          context.status(200),
+          context.json({
+            count: 1,
+          }),
+        );
+      }
+
+      return response(
+        context.status(400),
+      );
+    },
+  ),
+
+  // fetchUserName
+  rest.get(
+    `${apiBaseUrl}/users/me`,
+    async (request, response, context) => {
+      const accessToken = await request.headers.get('Authorization')
+        .substring('bearer '.length);
+
+      if (accessToken === 'userId 1') {
+        return response(
+          context.status(200),
+          context.json({
+            name: '황인우',
+          }),
+        );
+      }
+
+      if (accessToken === 'not existing userId 333') {
+        return response(
+          context.status(404),
+          context.json('User Not Found'),
+        );
+      }
+
+      return response(
+        context.status(400),
+      );
+    },
+  ),
+
+  // signUp
+  rest.post(
+    `${apiBaseUrl}/users`,
+    async (request, response, context) => {
+      const {
+        name,
+        username,
+        password,
+        confirmPassword,
+        gender,
+        phoneNumber,
+      } = await request.json();
+
+      if (name === '황인우'
+          && username === 'hsjkdss228'
+          && password === 'Password!1'
+          && confirmPassword === 'Password!1'
+          && gender === '남성'
+          && phoneNumber === '01012345678') {
+        return response(
+          context.status(201),
+          context.json({
+            enrolledName: '황인우',
+          }),
+        );
+      }
+
+      if (username === 'alreadyregisteredid12') {
         return response(
           context.status(400),
+          context.json('이미 등록된 아이디입니다.'),
         );
-      },
-    ),
+      }
+
+      if (password === 'Password!1'
+        && confirmPassword === 'wrongPassword!1') {
+        return response(
+          context.status(400),
+          context.json('비밀번호 확인이 일치하지 않습니다.'),
+        );
+      }
+
+      return response(
+        context.status(400),
+      );
+    },
   ),
 );
 


### PR DESCRIPTION
## Pages
- LoginPage
- NoticesPage
- PostFormPage
- PostPage
- PostsPage
- SignUpPage
- WelcomePage

### 과정
- 페이지 이동과 관련된 테스트 위주로 작성, 그 외의 페이지 이동과 관련되지 않은 부분은 jest.fn()으로 Mocking해 생략

## Stores
- GameStore
- NoticeStore
- PlaceStore
- PostFormStore
- PostStore
- RegisterStore
- UserStore

### 과정
- Store에서 상태를 변경하는 함수 호출 시 상태 값의 변경을 검증하는 테스트 진행
  - 필요하지 않거나 다른 상태와 중복되는 불필요한 상태값은 다른 상태와 통합시키거나 제외
- Store에서 API 요청을 보내는 함수 호출 시 모의 서버로부터 응답을 수신받아 상태를 의도한 대로 변경하는지 검증하는 테스트 진행
  - API 요청을 처리하는 서버에서 예외 처리를 하지 않고 있었을 경우 추가하고, 서버의 에러 응답 송신 형식과 프론트엔드의 에러 응답 수신 형식을 일치시킴

## 이슈
- 함수 호출 시 서버에 API 요청을 보내 데이터의 상태 변화를 유도하고, 변화된 상태를 다시 fetch해오는 API 요청의 테스트를 위해 모의 서버에 응답을 미리 정의해놓는 데 문제가 있었음
  - API 요청 양식이 완전히 똑같은데 서로 다른 응답을 주게 할 수 있는 경우의 세팅이 현재 수준에서는 불가능하다고 판단
  - 따라서 spy를 이용해 fetch 함수를 다시 호출했는지 수준으로 검증

32뽀모 사용